### PR TITLE
✨[FEAT] #10 : 티켓 기능 구현

### DIFF
--- a/src/main/java/cc/backend/amateurShow/entity/AmateurTicket.java
+++ b/src/main/java/cc/backend/amateurShow/entity/AmateurTicket.java
@@ -2,7 +2,7 @@ package cc.backend.amateurShow.entity;
 
 import cc.backend.amateurShow.entity.enums.TicketType;
 import cc.backend.domain.common.BaseEntity;
-import cc.backend.member.entity.MemberTicket;
+import cc.backend.ticket.entity.MemberTicket;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -37,10 +37,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     // MEMBER TICKET ERROR
-    MEMBER_TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBERTICKET4000", "존재하지 않는 예약 티켓입니다."),
-    MEMBER_TICKET_QUANTITY(HttpStatus.BAD_REQUEST, "MEMBERTICKET4001", "주문 수량이 적절하지 않습니다"),
-    MEMBER_TICKET_STOCK(HttpStatus.BAD_REQUEST, "MEMBERTICKET4002", "주문 수량이 재고를 초과했습니다"),
-    MEMBER_TICKET_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "MEMBERTICKET4003", "이미 취소하신 티켓입니다."),
+    MEMBER_TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "TICKET4000", "존재하지 않는 예약 티켓입니다."),
+    MEMBER_TICKET_QUANTITY(HttpStatus.BAD_REQUEST, "TICKET4001", "주문 수량이 적절하지 않습니다"),
+    MEMBER_TICKET_STOCK(HttpStatus.BAD_REQUEST, "TICKET4002", "주문 수량이 재고를 초과했습니다"),
+    MEMBER_TICKET_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "TICKET4003", "이미 취소하신 티켓입니다."),
+    MEMBER_TICKET_WRONG_STATUS(HttpStatus.BAD_REQUEST, "TICKET4004", "티켓의 상태가 적절하지 않습니다."),
 
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE4000", "이미지를 찾을 수 없습니다."),
     

--- a/src/main/java/cc/backend/member/entity/Member.java
+++ b/src/main/java/cc/backend/member/entity/Member.java
@@ -7,6 +7,7 @@ import cc.backend.member.enumerate.ActiveStatus;
 import cc.backend.member.enumerate.Role;
 import cc.backend.notice.entity.Notice;
 import cc.backend.photoAlbum.entity.PhotoAlbum;
+import cc.backend.ticket.entity.MemberTicket;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -57,6 +58,9 @@ public class Member extends BaseEntity {
 
     @OneToMany (mappedBy = "member", cascade = CascadeType.ALL)
     private List<Notice> notices = new ArrayList<>();
+
+    @OneToMany (mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberTicket> memberTickets = new ArrayList<>();
 
     @Builder
     public Member(String username, String name, Role role, String address, String email, String phone,

--- a/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
+++ b/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
@@ -1,0 +1,39 @@
+package cc.backend.ticket.controller;
+
+import cc.backend.apiPayLoad.ApiResponse;
+import cc.backend.member.MemberService;
+import cc.backend.ticket.dto.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
+import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
+import cc.backend.ticket.service.MemberTicketService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "소극장 공연 티켓")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tickets")
+public class MemberTicketController {
+
+    private final MemberService memberService;
+    private final MemberTicketService memberTicketService;
+
+    @PostMapping("/{amateurTicketId}")
+    public ApiResponse<MemberTicketCreateResponseDTO> createMemberTicket(@PathVariable Long amateurTicketId,
+                                                                         @RequestBody MemberTicketCreateRequestDTO requestDTO) {
+        return ApiResponse.onSuccess(memberTicketService.create(amateurTicketId, requestDTO));
+
+    }
+
+    @GetMapping
+    public ApiResponse<List<MemberTicketListResponseDTO>> getMyTickets(
+            @RequestParam Long memberId,
+            @RequestParam(defaultValue = "ALL") String status) {
+
+        List<MemberTicketListResponseDTO> tickets = memberTicketService.getMyTickets(memberId, status);
+        return ApiResponse.onSuccess(tickets);
+    }
+}

--- a/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
+++ b/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
@@ -2,9 +2,10 @@ package cc.backend.ticket.controller;
 
 import cc.backend.apiPayLoad.ApiResponse;
 import cc.backend.member.MemberService;
-import cc.backend.ticket.dto.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.response.MemberTicketListResponseDTO;
 import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
 import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
+import cc.backend.ticket.dto.response.MemberTicketResponseDTO;
 import cc.backend.ticket.service.MemberTicketService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +30,26 @@ public class MemberTicketController {
     }
 
     @GetMapping
-    public ApiResponse<List<MemberTicketListResponseDTO>> getMyTickets(
+    public ApiResponse<List<MemberTicketListResponseDTO>> getMyTicketList(
             @RequestParam Long memberId,
             @RequestParam(defaultValue = "ALL") String status) {
 
-        List<MemberTicketListResponseDTO> tickets = memberTicketService.getMyTickets(memberId, status);
+        List<MemberTicketListResponseDTO> tickets = memberTicketService.getMyTicketList(memberId, status);
         return ApiResponse.onSuccess(tickets);
+    }
+
+    @GetMapping("/{ticketId}")
+    public ApiResponse<MemberTicketResponseDTO> getMyTicket(@PathVariable Long ticketId,
+                                                                @RequestParam Long memberId) {
+
+        MemberTicketResponseDTO myTicket = memberTicketService.getMyTicket(memberId, ticketId);
+        return ApiResponse.onSuccess(myTicket);
+    }
+
+    @PatchMapping("/{ticketId}")
+    public ApiResponse<MemberTicketResponseDTO> cancelTicket(@PathVariable Long ticketId,
+                                                             @RequestParam Long memberId) {
+        MemberTicketResponseDTO myTicket = memberTicketService.cancelTicket(memberId, ticketId);
+        return ApiResponse.onSuccess(myTicket);
     }
 }

--- a/src/main/java/cc/backend/ticket/dto/MemberTicketListResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/MemberTicketListResponseDTO.java
@@ -1,0 +1,37 @@
+package cc.backend.ticket.dto;
+
+import cc.backend.ticket.entity.MemberTicket;
+import cc.backend.ticket.entity.enums.ReservationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MemberTicketListResponseDTO {
+
+    private Long ticketId;
+    private String showTitle;
+    private int quantity;
+    private String place;
+    private LocalDateTime reserveDate;
+    private LocalDateTime performanceDateTime;
+    private LocalDateTime cancelAvailableUntil;
+    private ReservationStatus reservationStatus;
+
+    public static MemberTicketListResponseDTO from(MemberTicket ticket) {
+        return MemberTicketListResponseDTO.builder()
+                .ticketId(ticket.getId())
+                .showTitle(ticket.getAmateurTicket().getAmateurShow().getName())
+                .place(ticket.getAmateurTicket().getAmateurShow().getPlace())
+                .quantity(ticket.getQuantity())
+                .reserveDate(ticket.getReserveDate())
+                .performanceDateTime(ticket.getPerformanceDateTime())
+                .cancelAvailableUntil(ticket.getCancelAvailableUntil())
+                .reservationStatus(ticket.getReservationStatus())
+                .build();
+    }
+}

--- a/src/main/java/cc/backend/ticket/dto/request/MemberTicketCreateRequestDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/request/MemberTicketCreateRequestDTO.java
@@ -1,0 +1,19 @@
+package cc.backend.ticket.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberTicketCreateRequestDTO {
+    private Long memberId;              // 예매자
+    //private Long amateurTicketId;       // 공연 티켓 ID
+    private int quantity;               // 수량
+    private LocalDateTime performanceDateTime; // 관람일시
+}

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketCreateResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketCreateResponseDTO.java
@@ -1,0 +1,29 @@
+package cc.backend.ticket.dto.response;
+
+import cc.backend.ticket.entity.enums.ReservationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MemberTicketCreateResponseDTO {
+    private Long ticketId;
+
+    private String showTitle;               // 공연 이름
+    private String place;                   // 공연 장소
+    private int quantity;                   // 예매 수량
+    private LocalDateTime reserveDate;      // 예매일
+    private LocalDateTime performanceDateTime; // 관람일시
+    private LocalDateTime cancelAvailableUntil; // 취소 가능 기한
+    private int totalPrice;                 // 결제 금액
+    private String discountName;            // 할인명
+    private ReservationStatus reservationStatus; // 상태 (예매 완료 / 취소 등)
+
+
+}

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketListResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketListResponseDTO.java
@@ -1,0 +1,35 @@
+package cc.backend.ticket.dto.response;
+
+import cc.backend.ticket.entity.MemberTicket;
+import cc.backend.ticket.entity.enums.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MemberTicketListResponseDTO {
+
+    private Long ticketId;
+    private String showTitle;
+    private int quantity;
+    private String place;
+    private LocalDateTime reserveDate;
+    private LocalDateTime performanceDateTime;
+    private LocalDateTime cancelAvailableUntil;
+    private ReservationStatus reservationStatus;
+
+    public static MemberTicketListResponseDTO from(MemberTicket ticket) {
+        return MemberTicketListResponseDTO.builder()
+                .ticketId(ticket.getId())
+                .showTitle(ticket.getAmateurTicket().getAmateurShow().getName())
+                .place(ticket.getAmateurTicket().getAmateurShow().getPlace())
+                .quantity(ticket.getQuantity())
+                .reserveDate(ticket.getReserveDate())
+                .performanceDateTime(ticket.getPerformanceDateTime())
+                .cancelAvailableUntil(ticket.getCancelAvailableUntil())
+                .reservationStatus(ticket.getReservationStatus())
+                .build();
+    }
+}

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketResponseDTO.java
@@ -1,18 +1,18 @@
-package cc.backend.ticket.dto;
+package cc.backend.ticket.dto.response;
+
 
 import cc.backend.ticket.entity.MemberTicket;
 import cc.backend.ticket.entity.enums.ReservationStatus;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
-public class MemberTicketListResponseDTO {
+public class MemberTicketResponseDTO {
 
+    //private String posterUrl;
     private Long ticketId;
     private String showTitle;
     private int quantity;
@@ -22,8 +22,9 @@ public class MemberTicketListResponseDTO {
     private LocalDateTime cancelAvailableUntil;
     private ReservationStatus reservationStatus;
 
-    public static MemberTicketListResponseDTO from(MemberTicket ticket) {
-        return MemberTicketListResponseDTO.builder()
+    public static MemberTicketResponseDTO from(MemberTicket ticket) {
+        return MemberTicketResponseDTO.builder()
+                //.posterUrl(ticket.getAmateurTicket().getAmateurShow().getPosterUrl())
                 .ticketId(ticket.getId())
                 .showTitle(ticket.getAmateurTicket().getAmateurShow().getName())
                 .place(ticket.getAmateurTicket().getAmateurShow().getPlace())

--- a/src/main/java/cc/backend/ticket/entity/MemberTicket.java
+++ b/src/main/java/cc/backend/ticket/entity/MemberTicket.java
@@ -45,7 +45,7 @@ public class MemberTicket extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public void cancelTicket(ReservationStatus reservationStatus) {
+    public void updateReservationStatus(ReservationStatus reservationStatus) {
         this.reservationStatus = reservationStatus;
     }
 

--- a/src/main/java/cc/backend/ticket/entity/MemberTicket.java
+++ b/src/main/java/cc/backend/ticket/entity/MemberTicket.java
@@ -1,7 +1,9 @@
-package cc.backend.member.entity;
+package cc.backend.ticket.entity;
 
 import cc.backend.amateurShow.entity.AmateurTicket;
 import cc.backend.domain.common.BaseEntity;
+import cc.backend.member.entity.Member;
+import cc.backend.ticket.entity.enums.ReservationStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,16 +23,19 @@ public class MemberTicket extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Integer quantity;
+    private int quantity;
 
-    private Integer totalPrice;
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus reservationStatus;
 
-    private LocalDateTime reservationTime;
+    private LocalDateTime reserveDate;
 
-    private String accountName;
+    private LocalDateTime performanceDateTime;
 
-//    @Enumerated(EnumType.STRING)
-//    private ReservationStatus reservationStatus;
+    private LocalDateTime cancelAvailableUntil;
+
+    private int totalPrice;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "amateur_ticket_id")
@@ -40,11 +45,11 @@ public class MemberTicket extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-//    public void cancelTicket(ReservationStatus reservationStatus) {
-//        this.reservationStatus = reservationStatus;
-//    }
-//
-//    public void updateMemberTicket(ReservationStatus reservationStatus) {
-//        this.reservationStatus = reservationStatus;
-//    }
+    public void cancelTicket(ReservationStatus reservationStatus) {
+        this.reservationStatus = reservationStatus;
+    }
+
+    public void updateMemberTicket(ReservationStatus reservationStatus) {
+        this.reservationStatus = reservationStatus;
+    }
 }

--- a/src/main/java/cc/backend/ticket/entity/enums/ReservationStatus.java
+++ b/src/main/java/cc/backend/ticket/entity/enums/ReservationStatus.java
@@ -1,0 +1,5 @@
+package cc.backend.ticket.entity.enums;
+
+public enum ReservationStatus {
+    PENDING, RESERVED, CANCELLED
+}

--- a/src/main/java/cc/backend/ticket/entity/enums/ReservationStatus.java
+++ b/src/main/java/cc/backend/ticket/entity/enums/ReservationStatus.java
@@ -1,5 +1,5 @@
 package cc.backend.ticket.entity.enums;
 
 public enum ReservationStatus {
-    PENDING, RESERVED, CANCELLED
+    PENDING, RESERVED, CANCELLED, USED
 }

--- a/src/main/java/cc/backend/ticket/repository/MemberTicketRepository.java
+++ b/src/main/java/cc/backend/ticket/repository/MemberTicketRepository.java
@@ -6,11 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MemberTicketRepository extends JpaRepository<MemberTicket, Long> {
 
     List<MemberTicket> findAllByMemberId(Long memberId);
     List<MemberTicket> findAllByMemberIdAndReservationStatus(Long memberId, ReservationStatus reservationStatus);
+    Optional<MemberTicket> findByMemberIdAndId(Long memberId, Long ticketId);
 
 }

--- a/src/main/java/cc/backend/ticket/repository/MemberTicketRepository.java
+++ b/src/main/java/cc/backend/ticket/repository/MemberTicketRepository.java
@@ -1,0 +1,16 @@
+package cc.backend.ticket.repository;
+
+import cc.backend.ticket.entity.MemberTicket;
+import cc.backend.ticket.entity.enums.ReservationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemberTicketRepository extends JpaRepository<MemberTicket, Long> {
+
+    List<MemberTicket> findAllByMemberId(Long memberId);
+    List<MemberTicket> findAllByMemberIdAndReservationStatus(Long memberId, ReservationStatus reservationStatus);
+
+}

--- a/src/main/java/cc/backend/ticket/service/MemberTicketService.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketService.java
@@ -1,8 +1,9 @@
 package cc.backend.ticket.service;
 
-import cc.backend.ticket.dto.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.response.MemberTicketListResponseDTO;
 import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
 import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
+import cc.backend.ticket.dto.response.MemberTicketResponseDTO;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -11,7 +12,10 @@ import java.util.List;
 public interface MemberTicketService {
 
     MemberTicketCreateResponseDTO create(Long amateurTicketID, MemberTicketCreateRequestDTO requestDTO);
-    List<MemberTicketListResponseDTO> getMyTickets(Long memberId, String status);
+    List<MemberTicketListResponseDTO> getMyTicketList(Long memberId, String status);
+    MemberTicketResponseDTO getMyTicket(Long memberId, Long ticketId);
+    MemberTicketResponseDTO cancelTicket(Long memberId, Long ticketId);
+
 
 
 }

--- a/src/main/java/cc/backend/ticket/service/MemberTicketService.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketService.java
@@ -1,0 +1,17 @@
+package cc.backend.ticket.service;
+
+import cc.backend.ticket.dto.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
+import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface MemberTicketService {
+
+    MemberTicketCreateResponseDTO create(Long amateurTicketID, MemberTicketCreateRequestDTO requestDTO);
+    List<MemberTicketListResponseDTO> getMyTickets(Long memberId, String status);
+
+
+}

--- a/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
@@ -1,0 +1,99 @@
+package cc.backend.ticket.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import cc.backend.amateurShow.entity.AmateurTicket;
+import cc.backend.amateurShow.repository.*;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.member.entity.Member;
+import cc.backend.member.repository.MemberRepository;
+import cc.backend.ticket.dto.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
+import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
+import cc.backend.ticket.entity.MemberTicket;
+import cc.backend.ticket.entity.enums.ReservationStatus;
+import cc.backend.ticket.repository.MemberTicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberTicketServiceImpl implements MemberTicketService {
+
+    private final MemberRepository memberRepository;
+    private final MemberTicketRepository memberTicketRepository;
+    private final AmateurShowRepository amateurShowRepository;
+    private final AmateurCastingRepository amateurCastingRepository;
+    private final AmateurNoticeRepository amateurNoticeRepository;
+    private final AmateurTicketRepository amateurTicketRepository;
+    private final AmateurSummaryRepository amateurSummaryRepository;
+    private final AmateurStaffRepository amateurStaffRepository;
+    private final AmateurRoundsRepository amateurRoundsRepository;
+
+
+    @Override
+    @Transactional
+    public MemberTicketCreateResponseDTO create(Long amateurTicketId, MemberTicketCreateRequestDTO requestDTO) {
+        Member member = memberRepository.findById(requestDTO.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        AmateurTicket amateurTicket = amateurTicketRepository.findById(amateurTicketId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_TICKET_NOT_FOUND));
+
+        int totalPrice = requestDTO.getQuantity() * amateurTicket.getPrice();
+
+        MemberTicket ticket = MemberTicket.builder()
+                .member(member)
+                .amateurTicket(amateurTicket)
+                .quantity(requestDTO.getQuantity())
+                .reserveDate(LocalDateTime.now())
+                .performanceDateTime(requestDTO.getPerformanceDateTime())
+                .cancelAvailableUntil(requestDTO.getPerformanceDateTime().minusDays(1).withHour(17))
+                .totalPrice(totalPrice)
+                .reservationStatus(ReservationStatus.RESERVED)
+                .build();
+
+        MemberTicket saved = memberTicketRepository.save(ticket);
+
+        return MemberTicketCreateResponseDTO.builder()
+                .ticketId(saved.getId())
+                .showTitle(amateurTicket.getAmateurShow().getName())
+                .place(amateurTicket.getAmateurShow().getPlace())
+                .quantity(saved.getQuantity())
+                .reserveDate(saved.getReserveDate())
+                .performanceDateTime(saved.getPerformanceDateTime())
+                .cancelAvailableUntil(saved.getCancelAvailableUntil())
+                .totalPrice(saved.getTotalPrice())
+                .reservationStatus(saved.getReservationStatus())
+                .build();
+    }
+
+    @Override
+    public List<MemberTicketListResponseDTO> getMyTickets(Long memberId, String status){
+        ReservationStatus filter = null;
+        if (!status.equalsIgnoreCase("ALL")) {
+            try {
+                filter = ReservationStatus.valueOf(status.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new GeneralException(ErrorStatus.MEMBER_TICKET_WRONG_STATUS);
+            }
+        }
+
+        List<MemberTicket> tickets = (filter == null)
+                ? memberTicketRepository.findAllByMemberId(memberId)
+                : memberTicketRepository.findAllByMemberIdAndReservationStatus(memberId, filter);
+
+        return tickets.stream()
+                .map(MemberTicketListResponseDTO::from)
+                .toList();
+    }
+
+
+
+
+
+}

--- a/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
@@ -9,9 +9,10 @@ import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.apiPayLoad.exception.GeneralException;
 import cc.backend.member.entity.Member;
 import cc.backend.member.repository.MemberRepository;
-import cc.backend.ticket.dto.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.response.MemberTicketListResponseDTO;
 import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
 import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
+import cc.backend.ticket.dto.response.MemberTicketResponseDTO;
 import cc.backend.ticket.entity.MemberTicket;
 import cc.backend.ticket.entity.enums.ReservationStatus;
 import cc.backend.ticket.repository.MemberTicketRepository;
@@ -73,7 +74,7 @@ public class MemberTicketServiceImpl implements MemberTicketService {
     }
 
     @Override
-    public List<MemberTicketListResponseDTO> getMyTickets(Long memberId, String status){
+    public List<MemberTicketListResponseDTO> getMyTicketList(Long memberId, String status){
         ReservationStatus filter = null;
         if (!status.equalsIgnoreCase("ALL")) {
             try {
@@ -92,6 +93,24 @@ public class MemberTicketServiceImpl implements MemberTicketService {
                 .toList();
     }
 
+    @Override
+    public MemberTicketResponseDTO getMyTicket(Long memberId, Long ticketId) {
+        MemberTicket memberTicket = memberTicketRepository.findByMemberIdAndId(memberId, ticketId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_TICKET_NOT_FOUND));
+        return MemberTicketResponseDTO.from(memberTicket);
+    }
+
+    @Override
+    @Transactional
+    public MemberTicketResponseDTO cancelTicket(Long memberId, Long ticketId) {
+        MemberTicket memberTicket = memberTicketRepository.findByMemberIdAndId(memberId, ticketId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_TICKET_NOT_FOUND));
+        if (memberTicket.getReservationStatus().equals(ReservationStatus.CANCELLED)) {
+            throw new GeneralException(ErrorStatus.MEMBER_TICKET_ALREADY_CANCELED);
+        }
+        memberTicket.updateReservationStatus(ReservationStatus.CANCELLED);
+        return MemberTicketResponseDTO.from(memberTicket);
+    }
 
 
 


### PR DESCRIPTION
<img width="1463" alt="image" src="https://github.com/user-attachments/assets/eb903aa0-9550-4030-bee3-fe3b17370192" />

공통 : memberId를 파라미터로 받습니다. 
@AuthenticationPrincipal 구현후 수정하겠습니다.

## 티켓 생성

## 티켓 리스트 조회

현재 requestParam으로 예약상태 (pending, cancelled, reserved, used) + all 필터로
로 조회 가능하도록 구현 했습니다.

## 티켓 단건 조회

소극장 등록이 수정되면, 포스터 이미지도 추가하겠습니다(현재 주석 상태)

## 티켓 예약 취소

이미 취소된 티켓에 있어서 이중 취소가 안되게 막았습니다.

