### PR TITLE
[FEATURE] #14 authentication principal 적용

### DIFF
--- a/src/main/java/cc/backend/board/controller/BoardController.java
+++ b/src/main/java/cc/backend/board/controller/BoardController.java
@@ -5,6 +5,7 @@ import cc.backend.board.dto.response.BoardDetailResponse;
 import cc.backend.board.dto.response.BoardResponse;
 import cc.backend.board.entity.enums.BoardType;
 import cc.backend.board.service.BoardService;
+import cc.backend.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,29 +33,29 @@ public class BoardController {
     @ApiResponse(responseCode = "200", description = "게시글 등록 성공",
             content = @Content(schema = @Schema(implementation = BoardResponse.class)))
     @PostMapping
-    public ResponseEntity<BoardResponse> createBoard(@Parameter(description = "작성자 회원 ID", required = true) @RequestParam Long memberId,
+    public ResponseEntity<BoardResponse> createBoard(@Parameter(description = "작성자 회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member,
                                                      @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "게시글 요청 DTO", required = true)
                                                      @RequestBody BoardRequest request) {
-        BoardResponse response= boardService.createBoard(memberId, request);
+        BoardResponse response= boardService.createBoard(member.getId(), request);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "게시글 수정 API", description = "게시글을 수정합니다.")
     @PutMapping("/{boardId}")
-    public ResponseEntity<BoardResponse> updateBoard(@Parameter(description = "작성자 회원 ID", required = true) @RequestParam Long memberId,
+    public ResponseEntity<BoardResponse> updateBoard(@Parameter(description = "작성자 회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member,
                                                      @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId,
                                                      @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "게시글 요청 DTO", required = true)@RequestBody BoardRequest request)
     {
-        BoardResponse response = boardService.updateBoard(memberId,boardId, request);
+        BoardResponse response = boardService.updateBoard(member.getId(), boardId, request);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다.")
     @DeleteMapping("/{boardId}")
     public ResponseEntity<Void> deleteBoard(
-            @Parameter(description = "작성자 회원 ID", required = true) @RequestParam Long memberId,
+            @Parameter(description = "작성자 회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member,
             @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId) {
-        boardService.deleteBoard(memberId,boardId);
+        boardService.deleteBoard(member.getId(),boardId);
         return ResponseEntity.noContent().build();
     }
 
@@ -78,8 +80,8 @@ public class BoardController {
     @PostMapping("/{boardId}/like")
     public ResponseEntity<?> toggleLike(
             @Parameter(description = "게시글 ID", required = true) @PathVariable Long boardId,
-            @Parameter(description = "회원 ID", required = true) @RequestParam Long memberId) {
-        int result = boardService.toggleLike(boardId, memberId);
+            @Parameter(description = "회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member) {
+        int result = boardService.toggleLike(boardId, member.getId());
         return ResponseEntity.ok(result);
     }
     @Operation(summary = "핫게시판 조회 API", description = "핫게시판(좋아요 10개 이상) 목록을 조회합니다.")

--- a/src/main/java/cc/backend/board/controller/CommentController.java
+++ b/src/main/java/cc/backend/board/controller/CommentController.java
@@ -4,6 +4,7 @@ import cc.backend.board.dto.request.CommentRequest;
 import cc.backend.board.dto.response.CommentCreateResponse;
 import cc.backend.board.dto.response.CommentResponse;
 import cc.backend.board.service.CommentService;
+import cc.backend.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -54,10 +56,10 @@ public class CommentController {
     @PatchMapping("/{commentId}")
     public ResponseEntity<CommentCreateResponse> updateComment(
             @Parameter(description = "댓글 ID", required = true) @PathVariable Long commentId,
-            @Parameter(description = "회원 ID", required = true) @RequestParam Long memberId,
+            @Parameter(description = "회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "수정할 댓글 내용", required = true)
             @RequestBody String newContent){
-        CommentCreateResponse response = commentService.updateComment(memberId, commentId, newContent);
+        CommentCreateResponse response = commentService.updateComment(member.getId(), commentId, newContent);
         return ResponseEntity.ok(response);
     }
 
@@ -72,8 +74,8 @@ public class CommentController {
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> deleteComment(
             @Parameter(description = "댓글 ID", required = true) @PathVariable Long commentId,
-            @Parameter(description = "회원 ID", required = true) @RequestParam Long memberId)  {
-        commentService.deleteComment(memberId, commentId);
+            @Parameter(description = "회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member)  {
+        commentService.deleteComment(member.getId(), commentId);
         return ResponseEntity.ok().build();
     }
 
@@ -104,8 +106,8 @@ public class CommentController {
     @PostMapping("/{commentId}/like")
     public ResponseEntity<Integer> toggleCommentLike(
                                                      @Parameter(description = "댓글 ID", required = true) @PathVariable Long commentId,
-                                                     @Parameter(description = "회원 ID", required = true) @RequestParam Long memberId) {
-        int result = commentService.toggleCommentLike(commentId, memberId);
+                                                     @Parameter(description = "회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member ) {
+        int result = commentService.toggleCommentLike(commentId, member.getId());
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/cc/backend/config/jwt/CustomUserDetails.java
+++ b/src/main/java/cc/backend/config/jwt/CustomUserDetails.java
@@ -1,0 +1,49 @@
+package cc.backend.config.jwt;
+
+import cc.backend.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CustomUserDetails implements UserDetails {
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(member.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/java/cc/backend/config/jwt/TokenProvider.java
+++ b/src/main/java/cc/backend/config/jwt/TokenProvider.java
@@ -1,8 +1,13 @@
 package cc.backend.config.jwt;
 
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.member.entity.Member;
+import cc.backend.member.repository.MemberRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -10,6 +15,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -27,11 +33,14 @@ public class TokenProvider {
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 5;            // 5시간
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
 
+    private final MemberRepository memberRepository;
+
     private final Key key;
 
-    public TokenProvider(@Value("${jwt.secret}") String secretKey) {
+    public TokenProvider(@Value("${jwt.secret}") String secretKey, MemberRepository memberRepository) {
         log.info("JWT Secret Key (Generation): {}", secretKey); // Secret Key 출력
 
+        this.memberRepository = memberRepository;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
@@ -73,6 +82,12 @@ public class TokenProvider {
         Claims claims = parseClaims(accessToken);
         log.info("🔍 클레임까지 옴 Claims: {}", claims);  // 여기서 claims 값을 확인
 
+        String email = claims.getSubject();
+
+        // Member 조회
+        Member member = memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
         // 🔍 auth 값이 존재하는 경우, GrantedAuthority로 변환
 //        String authorities = claims.get("auth", String.class);
 //        List<SimpleGrantedAuthority> grantedAuthorities = Collections.emptyList();
@@ -89,7 +104,7 @@ public class TokenProvider {
 //        return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
 //
          //권한 정보 없이 UserDetails 생성
-        UserDetails principal = new User(claims.getSubject(), "", new ArrayList<>());
+        UserDetails principal = new CustomUserDetails(member);
 
         return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
     }


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - #14 
2. **📝 작업 내용**
    - @AuthenticationPrincipal 적용을 위해 UserCustomDetails 구현
    - 게시판 관련 기능 member Id Param -> @AuthenticationPrincipal 변환
 4. **💬 리뷰 요구사항 (선택)**
    - 현일오빠 TokenProvider 수정된거 확인 부탁해용 혹시 내가 잘못 건드렸을수도있으니까..!
    > - TokenProvider 에서 member DB 조회하는게 책임분리가 불분명해 역할이 모호해질 수 있다는 생각이 듬.  
    > - UserDetailsService 을 따로 생성 : 서비스단에서 member 조회 후 UserDetails 반환  -> JWTFilter에서 UserDetails로 Authentication 생성
    > - 이렇게 리팩토링 하면 어떨까 싶은데..  기존의 코드 수정 많이해야해서 일단은 이렇게만 해둠. 지금 구조도 괜찮다구함

