### PR TITLE
[FEAT] 티켓 예매시 필요한 API 구현

### DIFF
--- a/src/main/java/cc/backend/amateurShow/dto/AmateurShowResponseDTO.java
+++ b/src/main/java/cc/backend/amateurShow/dto/AmateurShowResponseDTO.java
@@ -1,5 +1,6 @@
 package cc.backend.amateurShow.dto;
 
+import cc.backend.amateurShow.entity.AmateurShowStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -95,5 +96,18 @@ public class AmateurShowResponseDTO {
         private String place; // 공연장 주소
         private String schedule;
         private String posterImageUrl;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MyShowAmateurShowList { // 극장 공연 리스트 조회
+        private Long amateurShowId; // 소극장 공연 id
+        private String name; // 공연 이름
+        private String place; // 공연장 주소
+        private String schedule;
+        private String posterImageUrl;
+        private AmateurShowStatus status;
     }
 }

--- a/src/main/java/cc/backend/amateurShow/entity/AmateurShow.java
+++ b/src/main/java/cc/backend/amateurShow/entity/AmateurShow.java
@@ -49,6 +49,9 @@ public class AmateurShow extends BaseEntity {
 
     private Integer totalSoldTicket;
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private AmateurShowStatus status = AmateurShowStatus.APPROVED_YET;
 //    @Enumerated(EnumType.STRING)
 //    @Builder.Default
 //    private AmateurStatus amateurStatus = AmateurStatus.YET;

--- a/src/main/java/cc/backend/amateurShow/entity/AmateurShowStatus.java
+++ b/src/main/java/cc/backend/amateurShow/entity/AmateurShowStatus.java
@@ -1,0 +1,8 @@
+package cc.backend.amateurShow.entity;
+
+public enum AmateurShowStatus {
+    WAITING_APPROVAL, // 공연 등록만 하고, 관리자가 승인을 안 했을 때
+    APPROVED_YET, // 관리자가 승인을 하고, 지금 날짜가 공연 날짜 안에 없을 때 (아직 공연 예정)
+    APPROVED_ONGOING, // 관리자가 승인을 하고, 지금 날짜가 공연 날짜 안에 있을 때 (예매 진행 중)
+    APPROVED_ENDED    // 관리자가 승인을 하고, 지금 날짜가 공연 날짜보다 지났을 때 (공연 종료됨)
+}

--- a/src/main/java/cc/backend/amateurShow/repository/AmateurRoundsRepository.java
+++ b/src/main/java/cc/backend/amateurShow/repository/AmateurRoundsRepository.java
@@ -4,6 +4,10 @@ import cc.backend.amateurShow.entity.AmateurRounds;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AmateurRoundsRepository extends JpaRepository<AmateurRounds, Long> {
+    List<AmateurRounds> findByAmateurShowId(Long amateurShowId);
+
 }

--- a/src/main/java/cc/backend/amateurShow/repository/AmateurShowRepository.java
+++ b/src/main/java/cc/backend/amateurShow/repository/AmateurShowRepository.java
@@ -2,7 +2,10 @@ package cc.backend.amateurShow.repository;
 
 import cc.backend.amateurShow.entity.AmateurRounds;
 import cc.backend.amateurShow.entity.AmateurShow;
+import cc.backend.amateurShow.entity.AmateurShowStatus;
 import cc.backend.member.entity.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +23,15 @@ public interface AmateurShowRepository extends JpaRepository<AmateurShow, Long> 
 
     @Query("SELECT DISTINCT a FROM AmateurShow a LEFT JOIN FETCH a.amateurRounds WHERE a.member = :member")
     List<AmateurShow> findAllByMemberWithRounds(@Param("member") Member member);
+
+    @Query("SELECT a FROM AmateurShow a WHERE a.member.id = :memberId ORDER BY a.id DESC")
+    Slice<AmateurShow> findAllByMemberIdOrderByIdDesc(@Param("memberId") Long memberId, Pageable pageable);
+
+    @Query("SELECT a FROM AmateurShow a WHERE a.member.id = :memberId AND a.status = :status ORDER BY a.id DESC")
+    Slice<AmateurShow> findAllByMemberIdAndStatusOrderByIdDesc(@Param("memberId") Long memberId,
+                                                               @Param("status") AmateurShowStatus status,
+                                                               Pageable pageable);
+
+
+
 }

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
@@ -24,13 +24,7 @@ public interface AmateurService {
     Page<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Long memberId, Pageable pageable);
     List<AmateurShowResponseDTO.AmateurShowList> getShowRanking(Long memberId);
     List<AmateurShowResponseDTO.AmateurShowList> getShowClosing(Long memberId);
-    AmateurShowResponseDTO.AmateurShowResult getAmateurShow(Long amateurId);
-    AmateurEnrollResponseDTO.AmateurEnrollResult updateShow(Long showId, AmateurUpdateRequestDTO requestDTO);
-    void deleteShow(Long amateurShowId);
-    List<AmateurShowResponseDTO.AmateurShowList> getShowToday();
-    Page<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Pageable pageable);
-    List<AmateurShowResponseDTO.AmateurShowList> getShowRanking();
-    List<AmateurShowResponseDTO.AmateurShowList> getShowClosing();
+
 
     Slice<AmateurShowResponseDTO.MyShowAmateurShowList> getMyAmateurShow(Long memberId, AmateurShowStatus showStatus, Pageable pageable);
 

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
@@ -4,8 +4,10 @@ import cc.backend.amateurShow.dto.AmateurEnrollRequestDTO;
 import cc.backend.amateurShow.dto.AmateurEnrollResponseDTO;
 import cc.backend.amateurShow.dto.AmateurShowResponseDTO;
 import cc.backend.amateurShow.dto.AmateurUpdateRequestDTO;
+import cc.backend.amateurShow.entity.AmateurShowStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,4 +23,13 @@ public interface AmateurService {
     Page<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Long memberId, Pageable pageable);
     List<AmateurShowResponseDTO.AmateurShowList> getShowRanking(Long memberId);
     List<AmateurShowResponseDTO.AmateurShowList> getShowClosing(Long memberId);
+    AmateurShowResponseDTO.AmateurShowResult getAmateurShow(Long amateurId);
+    AmateurEnrollResponseDTO.AmateurEnrollResult updateShow(Long showId, AmateurUpdateRequestDTO requestDTO);
+    void deleteShow(Long amateurShowId);
+    List<AmateurShowResponseDTO.AmateurShowList> getShowToday();
+    Page<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Pageable pageable);
+    List<AmateurShowResponseDTO.AmateurShowList> getShowRanking();
+    List<AmateurShowResponseDTO.AmateurShowList> getShowClosing();
+
+    Slice<AmateurShowResponseDTO.MyShowAmateurShowList> getMyAmateurShow(Long memberId, AmateurShowStatus showStatus, Pageable pageable);
 }

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
@@ -5,6 +5,7 @@ import cc.backend.amateurShow.dto.AmateurEnrollResponseDTO;
 import cc.backend.amateurShow.dto.AmateurShowResponseDTO;
 import cc.backend.amateurShow.dto.AmateurUpdateRequestDTO;
 import cc.backend.amateurShow.entity.AmateurShowStatus;
+import cc.backend.ticket.dto.response.ReserveListResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -32,4 +33,6 @@ public interface AmateurService {
     List<AmateurShowResponseDTO.AmateurShowList> getShowClosing();
 
     Slice<AmateurShowResponseDTO.MyShowAmateurShowList> getMyAmateurShow(Long memberId, AmateurShowStatus showStatus, Pageable pageable);
+
+   // ReserveListResponseDTO getReserveListDetail(Long amateurShowId, Long memberId);
 }

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -9,6 +9,7 @@ import cc.backend.amateurShow.dto.AmateurEnrollRequestDTO;
 import cc.backend.amateurShow.dto.AmateurEnrollResponseDTO;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.board.entity.enums.BoardType;
 import cc.backend.event.entity.NewShowEvent;
 import cc.backend.image.DTO.ImageRequestDTO;
 import cc.backend.image.DTO.ImageResponseDTO;
@@ -17,6 +18,7 @@ import cc.backend.image.entity.Image;
 import cc.backend.image.repository.ImageRepository;
 import cc.backend.image.service.ImageService;
 import cc.backend.member.entity.Member;
+import cc.backend.member.enumerate.Role;
 import cc.backend.member.repository.MemberRepository;
 import cc.backend.memberLike.entity.MemberLike;
 import cc.backend.memberLike.repository.MemberLikeRepository;
@@ -25,6 +27,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -460,5 +463,32 @@ public class AmateurServiceImpl implements AmateurService {
         }
 
         return result;
+    }
+
+    @Override
+    public Slice<AmateurShowResponseDTO.MyShowAmateurShowList> getMyAmateurShow(Long memberId, AmateurShowStatus status, Pageable pageable) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (member.getRole() != Role.PERFORMER) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_PERFORMER);
+        }
+
+        Slice<AmateurShow> shows;
+
+        if (status == null) {
+            shows = amateurShowRepository.findAllByMemberIdOrderByIdDesc(memberId, pageable);
+        } else {
+            shows = amateurShowRepository.findAllByMemberIdAndStatusOrderByIdDesc(memberId, status, pageable);
+        }
+
+        return shows.map(show -> AmateurShowResponseDTO.MyShowAmateurShowList.builder()
+                .amateurShowId(show.getId())
+                .name(show.getName())
+                .place(show.getPlace())
+                .schedule(show.getSchedule())
+                .posterImageUrl(show.getPosterImageUrl())
+                .status(status)
+                .build());
     }
 }

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -22,6 +22,7 @@ import cc.backend.member.enumerate.Role;
 import cc.backend.member.repository.MemberRepository;
 import cc.backend.memberLike.entity.MemberLike;
 import cc.backend.memberLike.repository.MemberLikeRepository;
+import cc.backend.ticket.dto.response.ReserveListResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -491,4 +492,9 @@ public class AmateurServiceImpl implements AmateurService {
                 .status(status)
                 .build());
     }
+
+    //@Override
+    //public ReserveListResponseDTO getReserveListDetail(Long amateurShowId, Long memberId){
+    //    return null;
+    //}
 }

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -497,4 +497,5 @@ public class AmateurServiceImpl implements AmateurService {
     //public ReserveListResponseDTO getReserveListDetail(Long amateurShowId, Long memberId){
     //    return null;
     //}
+    
 }

--- a/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -54,8 +54,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // AMATEUR TICKET ERROR
     AMATEUR_TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "AMATEURTICKET4000", "존재하지 않는 소극장 공연 티켓입니다."),
     AMATEUR_TICKET_STOCK(HttpStatus.BAD_REQUEST, "AMATEURTICKET4001", "주문 수량은 최소 1개 이상이어야 합니다."),
-
-
+    AMATEUR_SHOW_MISMATCH(HttpStatus.NOT_FOUND, "AMATEURTICKET4002", "회차와 티켓에 해당하는 공연이 일치하지 않습니다."),
     // PHOTOALBUM ERROR
     PHOTOALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTOALBUM4000", "존재하지 않는 사진첩입니다."),
 

--- a/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -33,7 +33,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_INVALID_CODE(HttpStatus.BAD_REQUEST, "MEMBER4010", "토큰이 유효하지 않습니다."),
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "MEMBER4011", "해당 사용자게에게 관리자 권한이 없습니다."),
     MEMBER_ALREADY_DEACTIVATED(HttpStatus.BAD_REQUEST, "MEMBER4012", "해당 회원은 이미 탈퇴(비활성화) 상태입니다,"),
-    MEMBER_ALREADY_ACTIVATED(HttpStatus.BAD_REQUEST, "MEMBER4012", "해당 회원은 이미 활성화 상태입니다,"),
+    MEMBER_ALREADY_ACTIVATED(HttpStatus.BAD_REQUEST, "MEMBER4013", "해당 회원은 이미 활성화 상태입니다,"),
 
     // MEMBER TICKET ERROR
     MEMBER_TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "TICKET4000", "존재하지 않는 예약 티켓입니다."),

--- a/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -81,7 +81,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // MEMBER LIKE ERROR
 
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "LIKE4001", "존재하지 않는 좋아요입니다."),
-    DUPLICATE_LIKE(HttpStatus.BAD_REQUEST, "LIKE4002", "이미 좋아요한 공연진입니다.");
+    DUPLICATE_LIKE(HttpStatus.BAD_REQUEST, "LIKE4002", "이미 좋아요한 공연진입니다."),
+
+    // MYPAGE ERROR
+    MEMBER_NOT_PERFORMER(HttpStatus.FORBIDDEN, "MYPAGE4001", "등록자 계정이 아니기에 마이페이지 접근권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/cc/backend/board/repository/BoardRepository.java
+++ b/src/main/java/cc/backend/board/repository/BoardRepository.java
@@ -61,5 +61,10 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             @Param("boardType") BoardType boardType,
             @Param("keyword") String keyword,
             Pageable pageable);
+
+    // 내가 쓴 게시말 리스트
+    @Query("SELECT b FROM Board b WHERE b.member.id = :memberId ORDER BY b.id DESC")
+    Slice<Board> findAllByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
+
 }
 

--- a/src/main/java/cc/backend/board/service/BoardService.java
+++ b/src/main/java/cc/backend/board/service/BoardService.java
@@ -252,6 +252,14 @@ public class BoardService {
         return boardSlice.map(BoardDetailResponse::from);
     }
 
+    //내가 쓴 게시글 리스트 조회
+    @Transactional(readOnly = true)
+    public Slice<BoardDetailResponse> getMyBoards(Member member, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+        Slice<Board> boardSlice = boardRepository.findAllByMemberIdOrderByIdDesc(member.getId(), pageable);
+        return boardSlice.map(BoardDetailResponse::from);
+    }
+
     // --------------- 내부 메서드 ------------
     //핫게시판 선정 로직
     private void promoteToHotBoard(Board board) {

--- a/src/main/java/cc/backend/board/service/BoardService.java
+++ b/src/main/java/cc/backend/board/service/BoardService.java
@@ -254,7 +254,9 @@ public class BoardService {
 
     //내가 쓴 게시글 리스트 조회
     @Transactional(readOnly = true)
-    public Slice<BoardDetailResponse> getMyBoards(Member member, int page, int size) {
+    public Slice<BoardDetailResponse> getMyBoards(Long memberId, int page, int size) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
         Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
         Slice<Board> boardSlice = boardRepository.findAllByMemberIdOrderByIdDesc(member.getId(), pageable);
         return boardSlice.map(BoardDetailResponse::from);

--- a/src/main/java/cc/backend/member/MemberController.java
+++ b/src/main/java/cc/backend/member/MemberController.java
@@ -2,49 +2,107 @@ package cc.backend.member;
 
 
 import cc.backend.apiPayLoad.ApiResponse;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.member.dto.MyPageResponseDTO;
 import cc.backend.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+
 @RestController
 @RequestMapping("/member")
 @RequiredArgsConstructor
+@Tag(name = "회원 마이페이지", description = "마이페이지 조회 및 회원 활성/비활성화 API")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/{memberId}")
-    @Operation(summary = "[예매자 -> 본인] 마이 페이지 조회 api", description = "마이 페이지 조회 합니다")
-    public ApiResponse<MyPageResponseDTO> myPage(@AuthenticationPrincipal(expression = "member") Member member) {
-        MyPageResponseDTO myPageResponseDTO = memberService.getMyPage(member.getId());
-
-        return ApiResponse.onSuccess(myPageResponseDTO);
-
+    @GetMapping("/myPage")
+    @Operation(
+            summary = "마이 페이지 조회 API",
+            description = "현재 로그인한 회원의 마이 페이지 정보를 조회합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "마이페이지 조회 성공",
+                            content = @Content(schema = @Schema(implementation = MyPageResponseDTO.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "MEMBER4000 - 존재하지 않는 사용자입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorStatus.class))
+                    )
+            }
+    )
+    public ApiResponse<MyPageResponseDTO> myPage(
+            @Parameter(description = "로그인된 회원 정보", hidden = true)
+            @AuthenticationPrincipal(expression = "member") Member member
+    ) {
+        return ApiResponse.onSuccess(memberService.getMyPage(member.getId()));
     }
 
-    @PatchMapping("/{memberId}/deActive")
-    @Operation(summary = "회원 탈퇴(비활성화) api", description = "회원 비활성화 하는 기능입니다.")
-    public ApiResponse<MyPageResponseDTO> deactivateMember(@AuthenticationPrincipal(expression = "member") Member member) {
-        MyPageResponseDTO myPageResponseDTO = memberService.deactivateMember(member.getId());
-        return ApiResponse.onSuccess(myPageResponseDTO);
+    @PatchMapping("/myPage/deActive")
+    @Operation(
+            summary = "회원 탈퇴(비활성화) API",
+            description = "현재 로그인한 회원의 계정을 비활성화합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "회원 비활성화 성공",
+                            content = @Content(schema = @Schema(implementation = MyPageResponseDTO.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "MEMBER4000 - 존재하지 않는 사용자입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorStatus.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "MEMBER4012 - 해당 회원은 이미 탈퇴(비활성화) 상태입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorStatus.class))
+                    )
+            }
+    )
+    public ApiResponse<MyPageResponseDTO> deactivateMember(
+            @Parameter(description = "로그인된 회원 정보", hidden = true)
+            @AuthenticationPrincipal(expression = "member") Member member
+    ) {
+        return ApiResponse.onSuccess(memberService.deactivateMember(member.getId()));
     }
 
-    @PatchMapping("/{memberId}/reActive")
-    @Operation(summary = "회원 활성화 api", description = "회원 활성화 하는 기능입니다.")
-    public ApiResponse<MyPageResponseDTO> reactivateMember(@AuthenticationPrincipal(expression = "member") Member member) {
-        MyPageResponseDTO myPageResponseDTO = memberService.reactivateMember(member.getId());
-        return ApiResponse.onSuccess(myPageResponseDTO);
+    @PatchMapping("/myPage/reActive")
+    @Operation(
+            summary = "회원 활성화 API",
+            description = "현재 로그인한 회원의 계정을 다시 활성화합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "회원 활성화 성공",
+                            content = @Content(schema = @Schema(implementation = MyPageResponseDTO.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "MEMBER4000 - 존재하지 않는 사용자입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorStatus.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "MEMBER4013 - 해당 회원은 이미 활성화 상태입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorStatus.class))
+                    )
+            }
+    )
+    public ApiResponse<MyPageResponseDTO> reactivateMember(
+            @Parameter(description = "로그인된 회원 정보", hidden = true)
+            @AuthenticationPrincipal(expression = "member") Member member
+    ) {
+        return ApiResponse.onSuccess(memberService.reactivateMember(member.getId()));
     }
-
-//    @GetMapping("/{memberId}/performer")
-//    @Operation(summary = "[예매자 -> 공연진] 마이 페이지 조회 api", description = "공연진 페이지 조회 합니다")
-//    public ApiResponse<MyPageResponseDTO> performer(@PathVariable("memberId") Long memberId) {}
-//
-
-
 }

--- a/src/main/java/cc/backend/member/MemberController.java
+++ b/src/main/java/cc/backend/member/MemberController.java
@@ -1,10 +1,13 @@
 package cc.backend.member;
 
 
+import cc.backend.amateurShow.dto.AmateurShowResponseDTO;
+import cc.backend.amateurShow.entity.AmateurShowStatus;
+import cc.backend.amateurShow.service.amateurShowService.AmateurService;
 import cc.backend.apiPayLoad.ApiResponse;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.board.dto.response.BoardDetailResponse;
-import cc.backend.board.entity.enums.BoardType;
+import org.springframework.data.domain.Sort;
 import cc.backend.board.service.BoardService;
 import cc.backend.member.dto.MyPageResponseDTO;
 import cc.backend.member.entity.Member;
@@ -15,7 +18,10 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,6 +34,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final BoardService boardService;
+    private final AmateurService amateurService;
 
     @GetMapping("/myPage")
     @Operation(
@@ -112,14 +119,30 @@ public class MemberController {
     }
 
 
-    @Operation(summary = "게시글 목록 조회 API", description = "게시글을 무한 스크롤 방식으로 조회합니다.")
+    @Operation(summary = "내가 업로드한 게시글 목록 조회 API", description = "내가 업로드한 게시글을 무한 스크롤 방식으로 조회합니다.")
     @GetMapping("/myPage/myBoard")
     public Slice<BoardDetailResponse> getMyBoards(
             @Parameter(description = "작성자 회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member,
             @Parameter(description = "페이지 번호(0부터 시작)", required = true) @RequestParam int page,
             @Parameter(description = "페이지 크기", required = true) @RequestParam int size
     ) {
-        return boardService.getMyBoards(member, page, size);
+        return boardService.getMyBoards(member.getId(), page, size);
     }
 
+
+    @GetMapping("/myPage/myShow")
+    @Operation(summary = "내가 등록한 공연 조회", description = "등록자 계정으로 등록한 공연들을 무한 스크롤 방식으로 조회합니다.")
+    public Slice<AmateurShowResponseDTO.MyShowAmateurShowList> getMyShows(
+            @Parameter(description = "작성자 회원 ID", required = true)
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @Parameter(description = "페이지 번호(0부터 시작)", required = true)
+            @RequestParam int page,
+            @Parameter(description = "페이지 크기", required = true)
+            @RequestParam int size,
+            @Parameter(description = "공연 상태 필터 (전체: 생략, 예매 진행 중: RESERVING, 공연 종료: ENDED)", required = false)
+            @RequestParam(required = false) AmateurShowStatus status
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+        return amateurService.getMyAmateurShow(member.getId(), status, pageable);
+    }
 }

--- a/src/main/java/cc/backend/member/MemberController.java
+++ b/src/main/java/cc/backend/member/MemberController.java
@@ -3,6 +3,9 @@ package cc.backend.member;
 
 import cc.backend.apiPayLoad.ApiResponse;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.board.dto.response.BoardDetailResponse;
+import cc.backend.board.entity.enums.BoardType;
+import cc.backend.board.service.BoardService;
 import cc.backend.member.dto.MyPageResponseDTO;
 import cc.backend.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final BoardService boardService;
 
     @GetMapping("/myPage")
     @Operation(
@@ -105,4 +110,16 @@ public class MemberController {
     ) {
         return ApiResponse.onSuccess(memberService.reactivateMember(member.getId()));
     }
+
+
+    @Operation(summary = "게시글 목록 조회 API", description = "게시글을 무한 스크롤 방식으로 조회합니다.")
+    @GetMapping("/myPage/myBoard")
+    public Slice<BoardDetailResponse> getMyBoards(
+            @Parameter(description = "작성자 회원 ID", required = true) @AuthenticationPrincipal(expression = "member") Member member,
+            @Parameter(description = "페이지 번호(0부터 시작)", required = true) @RequestParam int page,
+            @Parameter(description = "페이지 크기", required = true) @RequestParam int size
+    ) {
+        return boardService.getMyBoards(member, page, size);
+    }
+
 }

--- a/src/main/java/cc/backend/member/MemberController.java
+++ b/src/main/java/cc/backend/member/MemberController.java
@@ -7,6 +7,7 @@ import cc.backend.amateurShow.service.amateurShowService.AmateurService;
 import cc.backend.apiPayLoad.ApiResponse;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.board.dto.response.BoardDetailResponse;
+import cc.backend.ticket.dto.response.ReserveListResponseDTO;
 import org.springframework.data.domain.Sort;
 import cc.backend.board.service.BoardService;
 import cc.backend.member.dto.MyPageResponseDTO;
@@ -139,10 +140,38 @@ public class MemberController {
             @RequestParam int page,
             @Parameter(description = "페이지 크기", required = true)
             @RequestParam int size,
-            @Parameter(description = "공연 상태 필터 (전체: 생략, 예매 진행 중: RESERVING, 공연 종료: ENDED)", required = false)
+            @Parameter(description = "공연 상태 필터 (전체: 생략, 예매 진행 중: APPROVED_ONGOING, 공연 종료: APPROVED_ENDED)", required = false)
             @RequestParam(required = false) AmateurShowStatus status
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
         return amateurService.getMyAmateurShow(member.getId(), status, pageable);
     }
+
+    @GetMapping("/myPage/reserveList")
+    @Operation(summary = "예매 내역 조회 첫화면", description = "등록자 계정으로 예매내역 조회를 누를시 나오는 첫화면입니다.")
+    public Slice<AmateurShowResponseDTO.MyShowAmateurShowList> getReserveList(
+            @Parameter(description = "작성자 회원 ID", required = true)
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @Parameter(description = "페이지 번호(0부터 시작)", required = true)
+            @RequestParam int page,
+            @Parameter(description = "페이지 크기", required = true)
+            @RequestParam int size,
+            @Parameter(description = "공연 상태 필터 (전체: 생략, 예매 진행 중: APPROVED_ONGOING, 공연 종료: APPROVED_ENDED)", required = false)
+            @RequestParam(required = false) AmateurShowStatus status
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+        return amateurService.getMyAmateurShow(member.getId(), status, pageable);
+    }
+
+/*    @GetMapping("/myPage/reserveList/{amateurShowId}")
+    @Operation(summary = "예매 내역 조회 상세보기", description = "등록자 계정으로 예매내역 조회 상세화면 입니다.")
+    public ReserveListResponseDTO getReserveListDetail(
+            @Parameter(description = "공연 ID", required = true)
+            @PathVariable Long amateurShowId,
+
+            @Parameter(description = "로그인한 회원 정보", required = true)
+            @AuthenticationPrincipal(expression = "member") Member member
+    ) {
+        return amateurService.getReserveListDetail(amateurShowId, member.getId());
+    }*/
 }

--- a/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
+++ b/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
@@ -3,10 +3,8 @@ package cc.backend.ticket.controller;
 import cc.backend.apiPayLoad.ApiResponse;
 import cc.backend.member.MemberService;
 import cc.backend.member.entity.Member;
-import cc.backend.ticket.dto.response.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.response.*;
 import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
-import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
-import cc.backend.ticket.dto.response.MemberTicketResponseDTO;
 import cc.backend.ticket.service.MemberTicketService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,6 +21,24 @@ public class MemberTicketController {
 
     private final MemberService memberService;
     private final MemberTicketService memberTicketService;
+
+    @GetMapping("/tickets/{amateurShowId}/selectRound")
+    @Operation(summary = "소극장 공연 티켓 예매 첫화면")
+    public ApiResponse<List<RoundsListDTO>> getAmateurRounds(@PathVariable Long amateurShowId,
+                                                             @AuthenticationPrincipal(expression = "member") Member member){
+
+        return ApiResponse.onSuccess(memberTicketService.getRoundsList(member.getId(), amateurShowId));
+
+    }
+
+    @GetMapping("/tickets/{amateurShowId}/selectTicket")
+    @Operation(summary = "소극장 공연 티켓 예매 두번재 화면")
+    public ApiResponse<List<AmateurTicketListDTO>> getAmateurTicketList(@PathVariable Long amateurShowId,
+                                                                    @AuthenticationPrincipal(expression = "member") Member member){
+
+        return ApiResponse.onSuccess(memberTicketService.getAmateurTicketList(member.getId(), amateurShowId));
+
+    }
 
     @PostMapping("/rounds/{amateurRoundId}/tickets/{amateurTicketId}")
     @Operation(summary = "소극장 공연 티켓 생성 API")

--- a/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
+++ b/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
@@ -7,9 +7,15 @@ import cc.backend.ticket.dto.response.*;
 import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
 import cc.backend.ticket.service.MemberTicketService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,23 +29,74 @@ public class MemberTicketController {
     private final MemberTicketService memberTicketService;
 
     @GetMapping("{amateurShowId}/showSimple")
-    @Operation(summary = "소극장 공연 티켓 예매 - 공연 정보 간략 보기 API")
-    public ApiResponse<AmateurShowSimpleDTO> getSimpleAmateurShow(@PathVariable Long amateurShowId,
-                                                                  @AuthenticationPrincipal(expression = "member") Member member) {
+    @Operation(
+            summary = "소극장 공연 티켓 예매 - 공연 정보 간략 보기 API",
+            description = "소극장 공연 티켓 예매 동안 보이는 모든 (화면 공연 사진, 공연 제목, 공연 장소)에 대해 나옵니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+                            description = "공연 간략 정보 조회 성공",
+                            content = @Content(schema = @Schema(implementation = AmateurShowSimpleDTO.class)))
+            }
+    )
+    public ApiResponse<AmateurShowSimpleDTO> getSimpleAmateurShow(@Parameter(name = "amateurShowId", description = "공연 ID", required = true) @PathVariable Long amateurShowId) {
         return ApiResponse.onSuccess(memberTicketService.getSimpleAmateurShow(amateurShowId));
     }
 
     @GetMapping("{amateurShowId}/selectRound")
-    @Operation(summary = "소극장 공연 티켓 예매 첫화면 - 회차(날짜) 선택 API")
+    @Operation(
+            summary = "소극장 공연 티켓 예매 첫화면 - 회차(날짜) 선택 API",
+            description = "소극장 공연 티켓 예매 첫화면에서 공연 회차를 선택하기전 조회하는 기능입니다. 등록된 공연의 모든 회차가 조회 됩니다.",
+            parameters = {
+                    @Parameter(name = "amateurShowId", description = "공연 ID", required = true),
+                    @Parameter(name = "member", hidden = true)
+            }
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회차 조회 성공",
+                    content = @Content(
+                            array = @ArraySchema(
+                                    schema = @Schema(implementation = RoundsListDTO.class)
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "공연을 찾을 수 없음",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
     public ApiResponse<List<RoundsListDTO>> getAmateurRounds(@PathVariable Long amateurShowId,
                                                              @AuthenticationPrincipal(expression = "member") Member member){
-
         return ApiResponse.onSuccess(memberTicketService.getRoundsList(member.getId(), amateurShowId));
-
     }
 
     @GetMapping("{amateurShowId}/selectTicket")
-    @Operation(summary = "소극장 공연 티켓 예매 두번재 화면 - 티켓 종류 선택 API")
+    @Operation(
+            summary = "소극장 공연 티켓 예매 두번째 화면 - 티켓 종류 선택 API",
+            description = "소극장 공연 티켓 예매 두번째화면에서 티켓 종류를 선택하기 전 조회하는 기능입니다. 등록된 공연의 모든 티켓이 조회됩니다.",
+            parameters = {
+                    @Parameter(name = "amateurShowId", description = "공연 ID", required = true),
+                    @Parameter(name = "member", hidden = true)
+            }
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "티켓 종류 조회 성공",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = AmateurTicketListDTO.class))
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "공연을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     public ApiResponse<List<AmateurTicketListDTO>> getAmateurTicketList(@PathVariable Long amateurShowId,
                                                                     @AuthenticationPrincipal(expression = "member") Member member){
 
@@ -48,7 +105,45 @@ public class MemberTicketController {
     }
 
     @PostMapping("{amateurShowId}/reserve")
-    @Operation(summary = "소극장 공연 티켓 생성 API")
+    @Operation(summary = "소극장 공연 티켓 생성 API",
+    description = "소극장 공연 티켓을 생성하는 기능입니다. 공연 회차, 인원, 티켓 종류를 선택해 생성합니다.",
+            parameters = {
+                    @Parameter(name = "amateurShowId", description = "공연 ID", required = true),
+                    @Parameter(name = "amateurRoundId", description = "회차 ID", required = true),
+                    @Parameter(name = "amateurTicketId", description = "티켓 ID", required = true),
+                    @Parameter(name = "member", hidden = true)
+            },
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "티켓 예매 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = MemberTicketCreateResponseDTO.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "공연 정보 불일치 또는 예매 가능 수량 초과",
+                            content = @Content(
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "공연, 회차 또는 티켓 정보를 찾을 수 없음",
+                            content = @Content(
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403",
+                            description = "권한 없음 (인증되지 않은 사용자)",
+                            content = @Content(
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            }
+    )
     public ApiResponse<MemberTicketCreateResponseDTO> createMemberTicket(
             @PathVariable Long amateurShowId,
             @RequestParam Long amateurRoundId,
@@ -60,30 +155,5 @@ public class MemberTicketController {
         );
     }
 
-    @GetMapping("/list")
-    @Operation(summary = "내 티켓 리스트 조회 API")
-    public ApiResponse<List<MemberTicketListResponseDTO>> getMyTicketList(
-            @AuthenticationPrincipal(expression = "member") Member member,
-            @RequestParam(defaultValue = "ALL") String status) {
 
-        List<MemberTicketListResponseDTO> tickets = memberTicketService.getMyTicketList(member.getId(), status);
-        return ApiResponse.onSuccess(tickets);
-    }
-
-    @GetMapping("{memberTicketId}/getMyTicket")
-    @Operation(summary = "내 티켓 단건 조회 API")
-    public ApiResponse<MemberTicketResponseDTO> getMyTicket(@PathVariable Long memberTicketId,
-                                                            @AuthenticationPrincipal(expression = "member") Member member) {
-
-        MemberTicketResponseDTO myTicket = memberTicketService.getMyTicket(member.getId(), memberTicketId);
-        return ApiResponse.onSuccess(myTicket);
-    }
-
-    @PatchMapping("{memberTicketId}/cancel")
-    @Operation(summary = "티켓 예약 취소하기 API")
-    public ApiResponse<MemberTicketResponseDTO> cancelTicket(@PathVariable Long memberTicketId,
-                                                             @AuthenticationPrincipal(expression = "member") Member member) {
-        MemberTicketResponseDTO myTicket = memberTicketService.cancelTicket(member.getId(), memberTicketId);
-        return ApiResponse.onSuccess(myTicket);
-    }
 }

--- a/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
+++ b/src/main/java/cc/backend/ticket/controller/MemberTicketController.java
@@ -17,13 +17,20 @@ import java.util.List;
 @Tag(name = "소극장 공연 티켓")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/tickets")
 public class MemberTicketController {
 
-    private final MemberService memberService;
     private final MemberTicketService memberTicketService;
 
-    @GetMapping("/tickets/{amateurShowId}/selectRound")
-    @Operation(summary = "소극장 공연 티켓 예매 첫화면")
+    @GetMapping("{amateurShowId}/showSimple")
+    @Operation(summary = "소극장 공연 티켓 예매 - 공연 정보 간략 보기 API")
+    public ApiResponse<AmateurShowSimpleDTO> getSimpleAmateurShow(@PathVariable Long amateurShowId,
+                                                                  @AuthenticationPrincipal(expression = "member") Member member) {
+        return ApiResponse.onSuccess(memberTicketService.getSimpleAmateurShow(amateurShowId));
+    }
+
+    @GetMapping("{amateurShowId}/selectRound")
+    @Operation(summary = "소극장 공연 티켓 예매 첫화면 - 회차(날짜) 선택 API")
     public ApiResponse<List<RoundsListDTO>> getAmateurRounds(@PathVariable Long amateurShowId,
                                                              @AuthenticationPrincipal(expression = "member") Member member){
 
@@ -31,8 +38,8 @@ public class MemberTicketController {
 
     }
 
-    @GetMapping("/tickets/{amateurShowId}/selectTicket")
-    @Operation(summary = "소극장 공연 티켓 예매 두번재 화면")
+    @GetMapping("{amateurShowId}/selectTicket")
+    @Operation(summary = "소극장 공연 티켓 예매 두번재 화면 - 티켓 종류 선택 API")
     public ApiResponse<List<AmateurTicketListDTO>> getAmateurTicketList(@PathVariable Long amateurShowId,
                                                                     @AuthenticationPrincipal(expression = "member") Member member){
 
@@ -40,17 +47,20 @@ public class MemberTicketController {
 
     }
 
-    @PostMapping("/rounds/{amateurRoundId}/tickets/{amateurTicketId}")
+    @PostMapping("{amateurShowId}/reserve")
     @Operation(summary = "소극장 공연 티켓 생성 API")
-    public ApiResponse<MemberTicketCreateResponseDTO> createMemberTicket(@PathVariable Long amateurRoundId,
-                                                                         @PathVariable Long amateurTicketId,
-                                                                         @AuthenticationPrincipal(expression = "member") Member member,
-                                                                         @RequestBody MemberTicketCreateRequestDTO requestDTO) {
-        return ApiResponse.onSuccess(memberTicketService.createTicket(amateurRoundId, amateurTicketId, member.getId(), requestDTO));
-
+    public ApiResponse<MemberTicketCreateResponseDTO> createMemberTicket(
+            @PathVariable Long amateurShowId,
+            @RequestParam Long amateurRoundId,
+            @RequestParam Long amateurTicketId,
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @RequestBody MemberTicketCreateRequestDTO requestDTO) {
+        return ApiResponse.onSuccess(
+                memberTicketService.createTicket(amateurShowId, amateurRoundId, amateurTicketId, member, requestDTO)
+        );
     }
 
-    @GetMapping("/tickets")
+    @GetMapping("/list")
     @Operation(summary = "내 티켓 리스트 조회 API")
     public ApiResponse<List<MemberTicketListResponseDTO>> getMyTicketList(
             @AuthenticationPrincipal(expression = "member") Member member,
@@ -60,7 +70,7 @@ public class MemberTicketController {
         return ApiResponse.onSuccess(tickets);
     }
 
-    @GetMapping("tickets/{memberTicketId}")
+    @GetMapping("{memberTicketId}/getMyTicket")
     @Operation(summary = "내 티켓 단건 조회 API")
     public ApiResponse<MemberTicketResponseDTO> getMyTicket(@PathVariable Long memberTicketId,
                                                             @AuthenticationPrincipal(expression = "member") Member member) {
@@ -69,7 +79,7 @@ public class MemberTicketController {
         return ApiResponse.onSuccess(myTicket);
     }
 
-    @PatchMapping("tickets/{memberTicketId}")
+    @PatchMapping("{memberTicketId}/cancel")
     @Operation(summary = "티켓 예약 취소하기 API")
     public ApiResponse<MemberTicketResponseDTO> cancelTicket(@PathVariable Long memberTicketId,
                                                              @AuthenticationPrincipal(expression = "member") Member member) {

--- a/src/main/java/cc/backend/ticket/controller/MyTicketController.java
+++ b/src/main/java/cc/backend/ticket/controller/MyTicketController.java
@@ -1,0 +1,140 @@
+package cc.backend.ticket.controller;
+
+import cc.backend.apiPayLoad.ApiResponse;
+import cc.backend.member.entity.Member;
+import cc.backend.ticket.dto.response.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.response.MemberTicketResponseDTO;
+import cc.backend.ticket.entity.enums.ReservationStatus;
+import cc.backend.ticket.service.MemberTicketService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "내 공연 티켓")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/myTickets")
+public class MyTicketController {
+    private final MemberTicketService memberTicketService;
+
+    @GetMapping("/list")
+    @Operation(
+            summary = "내 티켓 리스트 조회 API",
+            description = "회원의 예약된 공연 티켓 목록을 조회합니다. 상태(status)에 따라 필터링할 수 있습니다.",
+            parameters = {
+                    @Parameter(name = "status", description = "티켓 상태 (예: ALL, RESERVED, CANCELLED)", required = false),
+                    @Parameter(name = "member", hidden = true)
+            },
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "티켓 리스트 조회 성공",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = MemberTicketListResponseDTO.class)))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "유효하지 않은 status 파라미터",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403",
+                            description = "인증되지 않은 사용자",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
+    )
+    public ApiResponse<List<MemberTicketListResponseDTO>> getMyTicketList(
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @RequestParam(defaultValue = "ALL") String status) {
+
+        List<MemberTicketListResponseDTO> tickets = memberTicketService.getMyTicketList(member.getId(), status);
+        return ApiResponse.onSuccess(tickets);
+    }
+
+
+    @GetMapping("{memberTicketId}/getMyTicket")
+    @Operation(
+            summary = "내 티켓 단건 조회 API",
+            description = "회원이 예매한 특정 티켓(단건)의 상세 정보를 조회합니다.",
+            parameters = {
+                    @Parameter(name = "memberTicketId", description = "조회할 티켓 ID", required = true),
+                    @Parameter(name = "member", hidden = true)
+            },
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "티켓 상세 조회 성공",
+                            content = @Content(schema = @Schema(implementation = MemberTicketResponseDTO.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "해당 티켓이 존재하지 않거나 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403",
+                            description = "인증되지 않은 사용자",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
+    )
+    public ApiResponse<MemberTicketResponseDTO> getMyTicket(
+            @PathVariable Long memberTicketId,
+            @AuthenticationPrincipal(expression = "member") Member member) {
+
+        MemberTicketResponseDTO myTicket = memberTicketService.getMyTicket(member.getId(), memberTicketId);
+        return ApiResponse.onSuccess(myTicket);
+    }
+
+
+    @PatchMapping("{memberTicketId}/cancel")
+    @Operation(
+            summary = "티켓 예약 취소하기 API",
+            description = "회원이 예매한 티켓을 취소하는 기능입니다. 이미 취소된 티켓은 다시 취소할 수 없습니다.",
+            parameters = {
+                    @Parameter(name = "memberTicketId", description = "취소할 티켓 ID", required = true),
+                    @Parameter(name = "member", hidden = true)
+            },
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "티켓 예약 취소 성공",
+                            content = @Content(schema = @Schema(implementation = MemberTicketResponseDTO.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "티켓을 찾을 수 없음",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "409",
+                            description = "이미 취소된 티켓입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "403",
+                            description = "인증되지 않은 사용자",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
+    )
+    public ApiResponse<MemberTicketResponseDTO> cancelTicket(
+            @PathVariable Long memberTicketId,
+            @AuthenticationPrincipal(expression = "member") Member member) {
+
+        MemberTicketResponseDTO myTicket = memberTicketService.cancelTicket(member.getId(), memberTicketId);
+        return ApiResponse.onSuccess(myTicket);
+    }
+
+
+
+}

--- a/src/main/java/cc/backend/ticket/dto/response/AmateurShowSimpleDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/AmateurShowSimpleDTO.java
@@ -1,0 +1,17 @@
+package cc.backend.ticket.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class AmateurShowSimpleDTO {
+    private Long amateurShowId;
+    private String name;
+    private String place;
+    private String posterImageUrl;
+}

--- a/src/main/java/cc/backend/ticket/dto/response/AmateurTicketListDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/AmateurTicketListDTO.java
@@ -1,0 +1,16 @@
+package cc.backend.ticket.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class AmateurTicketListDTO {
+    private Long amateurTicketId;
+    private String discountName;
+    private Integer price;
+}

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketCreateResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketCreateResponseDTO.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 public class MemberTicketCreateResponseDTO {
-    private Long ticketId;
+    private Long memberTicketId;
 
     private String showTitle;               // 공연 이름
     private String place;                   // 공연 장소

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketCreateResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketCreateResponseDTO.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @Getter
 public class MemberTicketCreateResponseDTO {
     private Long memberTicketId;
-
+    private String bookingNumber;
     private String showTitle;               // 공연 이름
     private String place;                   // 공연 장소
     private int quantity;                   // 예매 수량

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketListResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketListResponseDTO.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 public class MemberTicketListResponseDTO {
 
     private Long memberTicketId;
+    private String bookingNumber;
     private String showTitle;
     private int quantity;
     private String place;
@@ -23,6 +24,7 @@ public class MemberTicketListResponseDTO {
     public static MemberTicketListResponseDTO from(MemberTicket ticket) {
         return MemberTicketListResponseDTO.builder()
                 .memberTicketId(ticket.getId())
+                .bookingNumber(ticket.getBookingNumber())
                 .showTitle(ticket.getAmateurTicket().getAmateurShow().getName())
                 .place(ticket.getAmateurTicket().getAmateurShow().getPlace())
                 .quantity(ticket.getQuantity())

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketListResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketListResponseDTO.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 public class MemberTicketListResponseDTO {
 
-    private Long ticketId;
+    private Long memberTicketId;
     private String showTitle;
     private int quantity;
     private String place;
@@ -22,7 +22,7 @@ public class MemberTicketListResponseDTO {
 
     public static MemberTicketListResponseDTO from(MemberTicket ticket) {
         return MemberTicketListResponseDTO.builder()
-                .ticketId(ticket.getId())
+                .memberTicketId(ticket.getId())
                 .showTitle(ticket.getAmateurTicket().getAmateurShow().getName())
                 .place(ticket.getAmateurTicket().getAmateurShow().getPlace())
                 .quantity(ticket.getQuantity())

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketResponseDTO.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 public class MemberTicketResponseDTO {
 
-    //private String posterUrl;
+    private String posterImageUrl;
     private Long memberTicketId;
     private String showTitle;
     private int quantity;
@@ -24,7 +24,7 @@ public class MemberTicketResponseDTO {
 
     public static MemberTicketResponseDTO from(MemberTicket ticket) {
         return MemberTicketResponseDTO.builder()
-                //.posterUrl(ticket.getAmateurTicket().getAmateurShow().getPosterUrl())
+                .posterImageUrl(ticket.getAmateurTicket().getAmateurShow().getPosterImageUrl())
                 .memberTicketId(ticket.getId())
                 .showTitle(ticket.getAmateurTicket().getAmateurShow().getName())
                 .place(ticket.getAmateurTicket().getAmateurShow().getPlace())

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketResponseDTO.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 public class MemberTicketResponseDTO {
 
     //private String posterUrl;
-    private Long ticketId;
+    private Long memberTicketId;
     private String showTitle;
     private int quantity;
     private String place;
@@ -25,7 +25,7 @@ public class MemberTicketResponseDTO {
     public static MemberTicketResponseDTO from(MemberTicket ticket) {
         return MemberTicketResponseDTO.builder()
                 //.posterUrl(ticket.getAmateurTicket().getAmateurShow().getPosterUrl())
-                .ticketId(ticket.getId())
+                .memberTicketId(ticket.getId())
                 .showTitle(ticket.getAmateurTicket().getAmateurShow().getName())
                 .place(ticket.getAmateurTicket().getAmateurShow().getPlace())
                 .quantity(ticket.getQuantity())

--- a/src/main/java/cc/backend/ticket/dto/response/MemberTicketResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/MemberTicketResponseDTO.java
@@ -14,6 +14,7 @@ public class MemberTicketResponseDTO {
 
     private String posterImageUrl;
     private Long memberTicketId;
+    private String bookingNumber;
     private String showTitle;
     private int quantity;
     private String place;
@@ -26,6 +27,7 @@ public class MemberTicketResponseDTO {
         return MemberTicketResponseDTO.builder()
                 .posterImageUrl(ticket.getAmateurTicket().getAmateurShow().getPosterImageUrl())
                 .memberTicketId(ticket.getId())
+                .bookingNumber(ticket.getBookingNumber())
                 .showTitle(ticket.getAmateurTicket().getAmateurShow().getName())
                 .place(ticket.getAmateurTicket().getAmateurShow().getPlace())
                 .quantity(ticket.getQuantity())

--- a/src/main/java/cc/backend/ticket/dto/response/ReserveListResponseDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/ReserveListResponseDTO.java
@@ -1,0 +1,37 @@
+package cc.backend.ticket.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ReserveListResponseDTO {
+
+    private String showTitle;
+    private String showPosterUrl;
+    private String place;
+    private String period;
+
+    private List<RoundReservationInfo> rounds;
+
+    @Getter
+    @Builder
+    public static class RoundReservationInfo {
+        private Long roundId;
+        private Integer roundNumber;
+        private String performanceDateTime; // YYYY-MM-DD (요일) HH:mm
+        private Integer reservedCount;
+        private Integer totalTicket;
+        private List<TicketDetail> ticketDetails;
+    }
+
+    @Getter
+    @Builder
+    public static class TicketDetail {
+        private String discountName;
+        private Integer price;
+        private Integer quantity;
+    }
+}

--- a/src/main/java/cc/backend/ticket/dto/response/RoundsListDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/response/RoundsListDTO.java
@@ -1,0 +1,18 @@
+package cc.backend.ticket.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RoundsListDTO {
+    private Long roundId;
+    private Integer roundNumber;
+    private LocalDateTime performanceDateTime;
+}

--- a/src/main/java/cc/backend/ticket/entity/MemberTicket.java
+++ b/src/main/java/cc/backend/ticket/entity/MemberTicket.java
@@ -24,18 +24,25 @@ public class MemberTicket extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private int quantity;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private ReservationStatus reservationStatus;
 
     private LocalDateTime reserveDate;
 
+    @Column(nullable = false)
     private LocalDateTime performanceDateTime;
 
     private LocalDateTime cancelAvailableUntil;
 
+    @Column(nullable = false)
     private int totalPrice;
+
+    @Column(nullable = false, unique = true)
+    private String bookingNumber;
 
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/cc/backend/ticket/service/MemberTicketService.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketService.java
@@ -11,12 +11,13 @@ import java.util.List;
 @Service
 public interface MemberTicketService {
 
-    MemberTicketCreateResponseDTO createTicket(Long amateurRoundId, Long amateurTicketId, Long memberId, MemberTicketCreateRequestDTO requestDTO);
+    MemberTicketCreateResponseDTO createTicket(Long amateurShowId, Long amateurRoundId, Long amateurTicketId, Member member, MemberTicketCreateRequestDTO requestDTO);
     List<MemberTicketListResponseDTO> getMyTicketList(Long memberId, String status);
     MemberTicketResponseDTO getMyTicket(Long memberId, Long memberTicketId);
     MemberTicketResponseDTO cancelTicket(Long memberId, Long memberTicketId);
     List<RoundsListDTO> getRoundsList(Long memberId, Long amateurShowId);
     List<AmateurTicketListDTO> getAmateurTicketList(Long memberId, Long amateurShowId);
+    AmateurShowSimpleDTO getSimpleAmateurShow(Long amateurShowId);
 
 
 }

--- a/src/main/java/cc/backend/ticket/service/MemberTicketService.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketService.java
@@ -1,10 +1,9 @@
 package cc.backend.ticket.service;
 
+import cc.backend.amateurShow.entity.AmateurTicket;
 import cc.backend.member.entity.Member;
-import cc.backend.ticket.dto.response.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.response.*;
 import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
-import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
-import cc.backend.ticket.dto.response.MemberTicketResponseDTO;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,7 +15,8 @@ public interface MemberTicketService {
     List<MemberTicketListResponseDTO> getMyTicketList(Long memberId, String status);
     MemberTicketResponseDTO getMyTicket(Long memberId, Long memberTicketId);
     MemberTicketResponseDTO cancelTicket(Long memberId, Long memberTicketId);
-
+    List<RoundsListDTO> getRoundsList(Long memberId, Long amateurShowId);
+    List<AmateurTicketListDTO> getAmateurTicketList(Long memberId, Long amateurShowId);
 
 
 }

--- a/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
@@ -42,19 +42,26 @@ public class MemberTicketServiceImpl implements MemberTicketService {
 
     @Override
     @Transactional
-    public MemberTicketCreateResponseDTO createTicket(Long amateurRoundId, Long amateurTicketId, Long memberId, MemberTicketCreateRequestDTO requestDTO) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException((ErrorStatus.MEMBER_NOT_AUTHORIZED)));
+    public MemberTicketCreateResponseDTO createTicket(Long amateurShowId, Long amateurRoundId, Long amateurTicketId, Member member, MemberTicketCreateRequestDTO requestDTO) {
+
+        AmateurShow show = amateurShowRepository.findById(amateurShowId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
         AmateurRounds round = amateurRoundsRepository.findById(amateurRoundId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ROUND_NOT_FOUND));
 
+        AmateurTicket amateurTicket = amateurTicketRepository.findById(amateurTicketId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEUR_TICKET_NOT_FOUND));
+
+        // 해당 회차와 티켓에 해당하는 공연이 일치 하는지
+        if (!amateurTicket.getAmateurShow().getId().equals(amateurShowId) || !round.getAmateurShow().getId().equals(amateurShowId)) {
+            throw new GeneralException(ErrorStatus.AMATEUR_SHOW_MISMATCH);
+        }
+
+        // 현재 예약하려는 티켓의 수량이 해당 회차의 재고수량을 초과하지 않는지
         if(requestDTO.getQuantity() > round.getTotalTicket()) {
             throw new GeneralException(ErrorStatus.MEMBER_TICKET_STOCK);
         }
-
-        AmateurTicket amateurTicket = amateurTicketRepository.findById(amateurTicketId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEUR_TICKET_NOT_FOUND));
 
 
         int totalPrice = requestDTO.getQuantity() * amateurTicket.getPrice();
@@ -80,7 +87,7 @@ public class MemberTicketServiceImpl implements MemberTicketService {
         eventPublisher.publishEvent(new TicketReservationEvent(ticket.getAmateurTicket().getAmateurShow(), ticket.getAmateurTicket(), member));
 
         return MemberTicketCreateResponseDTO.builder()
-                .ticketId(saved.getId())
+                .memberTicketId(saved.getId())
                 .showTitle(amateurTicket.getAmateurShow().getName())
                 .place(amateurTicket.getAmateurShow().getPlace())
                 .quantity(saved.getQuantity())
@@ -152,6 +159,19 @@ public class MemberTicketServiceImpl implements MemberTicketService {
                         t.getPrice()
                 )).toList();
     }
+
+    @Override
+    public AmateurShowSimpleDTO getSimpleAmateurShow(Long amateurShowId){
+        AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+        return AmateurShowSimpleDTO.builder()
+                .amateurShowId(amateurShowId)
+                .name(amateurShow.getName())
+                .place(amateurShow.getPlace())
+                .posterImageUrl(amateurShow.getPosterImageUrl())
+                .build();
+    }
+
 
 
 

--- a/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
@@ -2,7 +2,9 @@ package cc.backend.ticket.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Random;
 
 import cc.backend.amateurShow.entity.AmateurRounds;
 import cc.backend.amateurShow.entity.AmateurShow;
@@ -65,6 +67,7 @@ public class MemberTicketServiceImpl implements MemberTicketService {
 
 
         int totalPrice = requestDTO.getQuantity() * amateurTicket.getPrice();
+        String bookingNumber = generateBookingNumber();
 
         MemberTicket ticket = MemberTicket.builder()
                 .member(member)
@@ -72,6 +75,7 @@ public class MemberTicketServiceImpl implements MemberTicketService {
                 .amateurRound(round)
                 .quantity(requestDTO.getQuantity())
                 .reserveDate(LocalDateTime.now())
+                .bookingNumber(bookingNumber)
                 .performanceDateTime(round.getPerformanceDateTime())
                 .cancelAvailableUntil(round.getPerformanceDateTime().minusDays(1).withHour(17))
                 .totalPrice(totalPrice)
@@ -88,6 +92,7 @@ public class MemberTicketServiceImpl implements MemberTicketService {
 
         return MemberTicketCreateResponseDTO.builder()
                 .memberTicketId(saved.getId())
+                .bookingNumber(bookingNumber)
                 .showTitle(amateurTicket.getAmateurShow().getName())
                 .place(amateurTicket.getAmateurShow().getPlace())
                 .quantity(saved.getQuantity())
@@ -170,6 +175,14 @@ public class MemberTicketServiceImpl implements MemberTicketService {
                 .place(amateurShow.getPlace())
                 .posterImageUrl(amateurShow.getPosterImageUrl())
                 .build();
+    }
+
+
+    private String generateBookingNumber() {
+        String prefix = "TICKET";
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        int randomNum = new Random().nextInt(9000) + 1000; // 1000~9999
+        return  prefix + timestamp + randomNum;
     }
 
 

--- a/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
+++ b/src/main/java/cc/backend/ticket/service/MemberTicketServiceImpl.java
@@ -14,10 +14,8 @@ import cc.backend.event.entity.PromoteHotEvent;
 import cc.backend.event.entity.TicketReservationEvent;
 import cc.backend.member.entity.Member;
 import cc.backend.member.repository.MemberRepository;
-import cc.backend.ticket.dto.response.MemberTicketListResponseDTO;
+import cc.backend.ticket.dto.response.*;
 import cc.backend.ticket.dto.request.MemberTicketCreateRequestDTO;
-import cc.backend.ticket.dto.response.MemberTicketCreateResponseDTO;
-import cc.backend.ticket.dto.response.MemberTicketResponseDTO;
 import cc.backend.ticket.entity.MemberTicket;
 import cc.backend.ticket.entity.enums.ReservationStatus;
 import cc.backend.ticket.repository.MemberTicketRepository;
@@ -131,6 +129,28 @@ public class MemberTicketServiceImpl implements MemberTicketService {
         }
         memberTicket.updateReservationStatus(ReservationStatus.CANCELLED);
         return MemberTicketResponseDTO.from(memberTicket);
+    }
+
+    @Override
+    public List<RoundsListDTO> getRoundsList(Long memberId, Long amateurShowId){
+        List<AmateurRounds> rounds = amateurRoundsRepository.findByAmateurShowId(amateurShowId);
+        return rounds.stream()
+                .map(r -> new RoundsListDTO(
+                        r.getId(),
+                        r.getRoundNumber(),
+                        r.getPerformanceDateTime()
+                )).toList();
+    }
+
+    @Override
+    public List<AmateurTicketListDTO> getAmateurTicketList(Long memberId, Long amateurShowId){
+        List<AmateurTicket> tickets = amateurTicketRepository.findByAmateurShowId(amateurShowId);
+        return tickets.stream()
+                .map(t -> new AmateurTicketListDTO(
+                        t.getId(),
+                        t.getDiscountName(),
+                        t.getPrice()
+                )).toList();
     }
 
 


### PR DESCRIPTION
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/a9d643b1-df44-4948-9785-7e268f9f6580" />
고민중인게 있습니다.
amateurTicket : 공연의 티켓(할인 티켓, 일반 티켓 등)
memberTicket : 예약한 티켓 (실종 1회차 2매 홍대생할인 등)

각각 관련된 api가 예매, 마이페이지 이렇게 다른데, 프로젝트 파일에서도 다르게 분리할까요? 의견 부탁드립니다