### PR TITLE
[FEAT] 관리자페이지 사진첩 관리

### DIFF
--- a/src/main/java/cc/backend/admin/photoAlbum/controller/AdminPhotoAlbumController.java
+++ b/src/main/java/cc/backend/admin/photoAlbum/controller/AdminPhotoAlbumController.java
@@ -1,0 +1,58 @@
+package cc.backend.admin.photoAlbum.controller;
+
+import cc.backend.admin.photoAlbum.dto.AdminPhotoAlbumResponseDTO;
+import cc.backend.admin.photoAlbum.service.AdminPhotoAlbumService;
+import cc.backend.apiPayLoad.ApiResponse;
+import cc.backend.board.entity.enums.BoardType;
+import cc.backend.member.entity.Member;
+import cc.backend.notice.dto.MemberNoticeResponseDTO;
+import cc.backend.photoAlbum.service.PhotoAlbumService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/photoAlbum")
+@RequiredArgsConstructor
+@Tag(name = "관리자 사진첩 관리")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminPhotoAlbumController {
+    private final AdminPhotoAlbumService adminPhotoAlbumService;
+
+    @GetMapping("")
+    @Operation(summary = "관리자페이지 사진첩 전체 조회 API", description = "전체 사진첩 업로드 날짜 내림차순 정렬")
+    public ApiResponse<Page<AdminPhotoAlbumResponseDTO.SimplePhotoAlbumDTO>> getAllPhotoAlbum(
+            @Parameter(description = "페이지 번호(0부터 시작)", required = true) @RequestParam int page,
+            @Parameter(description = "페이지 크기", required = true) @RequestParam int size
+    ){
+        return ApiResponse.onSuccess(adminPhotoAlbumService.getAllPhotoAlbum(page, size));
+    }
+
+    @GetMapping("/{photoAlbumId}")
+    @Operation(summary = "관리자페이지 사진첩 상세 조회 API", description = "개별 사진첩 상세 조회")
+    public ApiResponse<AdminPhotoAlbumResponseDTO.DetailPhotoAlbumDTO> getPhotoAlbum(@PathVariable Long photoAlbumId){
+        return ApiResponse.onSuccess(adminPhotoAlbumService.getPhotoAlbumDetail(photoAlbumId));
+    }
+
+    @DeleteMapping("/{photoAlbumId}")
+    @Operation(summary = "관리자페이지 사진첩 내리기 API", description = "개별 사진첩 삭제")
+    public ApiResponse<String> deletePhotoAlbum(@PathVariable Long photoAlbumId){
+        return ApiResponse.onSuccess(adminPhotoAlbumService.deletePhotoAlbum(photoAlbumId));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "관리자페이지 사진첩 검색 API", description = "사진첩 id, 공연 id, 공연제목, 사진첩 내용에 키워드를 포함하면 반환")
+    public ApiResponse<List<AdminPhotoAlbumResponseDTO.SimplePhotoAlbumDTO>> searchPhotoAlbum(@RequestParam String keyword){
+        return ApiResponse.onSuccess(adminPhotoAlbumService.searchPhotoAlbum(keyword));
+    }
+
+
+
+}

--- a/src/main/java/cc/backend/admin/photoAlbum/dto/AdminPhotoAlbumResponseDTO.java
+++ b/src/main/java/cc/backend/admin/photoAlbum/dto/AdminPhotoAlbumResponseDTO.java
@@ -1,0 +1,43 @@
+package cc.backend.admin.photoAlbum.dto;
+
+import cc.backend.image.DTO.ImageResponseDTO;
+import cc.backend.notice.entity.enums.NoticeType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "관리자용 사진첩 관리 응답 DTO")
+public class AdminPhotoAlbumResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SimplePhotoAlbumDTO {
+        private Long id;
+        private String amateurShowName;
+        private Long uploaderId;
+        private String uploaderName;
+        private LocalDateTime updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailPhotoAlbumDTO {
+        private Long id;
+        private Long amateurShowId;
+        private String amateurShowName;
+        private Long uploaderId;
+        private String uploaderName;
+        private String content;
+        private LocalDateTime updatedAt;
+    }
+
+
+}

--- a/src/main/java/cc/backend/admin/photoAlbum/service/AdminPhotoAlbumService.java
+++ b/src/main/java/cc/backend/admin/photoAlbum/service/AdminPhotoAlbumService.java
@@ -1,0 +1,96 @@
+package cc.backend.admin.photoAlbum.service;
+
+import cc.backend.admin.photoAlbum.dto.AdminPhotoAlbumResponseDTO;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.image.FilePath;
+import cc.backend.image.entity.Image;
+import cc.backend.image.repository.ImageRepository;
+import cc.backend.image.service.ImageService;
+import cc.backend.member.entity.Member;
+import cc.backend.photoAlbum.entity.PhotoAlbum;
+import cc.backend.photoAlbum.repository.PhotoAlbumRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPhotoAlbumService {
+    private final PhotoAlbumRepository photoAlbumRepository;
+    private final ImageRepository imageRepository;
+    private final ImageService imageService;
+
+    @Transactional(readOnly = true)
+    public Page<AdminPhotoAlbumResponseDTO.SimplePhotoAlbumDTO> getAllPhotoAlbum(int page, int size){
+        Pageable pageable = PageRequest.of(page, size, Sort.by("updatedAt").descending());
+        Page<PhotoAlbum> photoAlbums = photoAlbumRepository.findAll(pageable);
+
+        return photoAlbums.map(photoAlbum -> AdminPhotoAlbumResponseDTO.SimplePhotoAlbumDTO.builder()
+                .id(photoAlbum.getId())
+                .amateurShowName(photoAlbum.getAmateurShow().getName())
+                .uploaderId(photoAlbum.getAmateurShow().getMember().getId())
+                .uploaderName(photoAlbum.getAmateurShow().getMember().getName())
+                .updatedAt(photoAlbum.getUpdatedAt())
+                .build());
+    }
+
+    @Transactional(readOnly = true)
+    public AdminPhotoAlbumResponseDTO.DetailPhotoAlbumDTO getPhotoAlbumDetail(Long photoAlbumId){
+        PhotoAlbum photoAlbum = photoAlbumRepository.findById(photoAlbumId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.PHOTOALBUM_NOT_FOUND));
+
+        return AdminPhotoAlbumResponseDTO.DetailPhotoAlbumDTO.builder()
+                .id(photoAlbum.getId())
+                .amateurShowId(photoAlbum.getAmateurShow().getId())
+                .amateurShowName(photoAlbum.getAmateurShow().getName())
+                .content(photoAlbum.getContent())
+                .uploaderId(photoAlbum.getAmateurShow().getMember().getId())
+                .uploaderName(photoAlbum.getAmateurShow().getMember().getName())
+                .updatedAt(photoAlbum.getUpdatedAt())
+                .build();
+    }
+
+    @Transactional
+    public String deletePhotoAlbum(Long photoAlbumId) {
+        PhotoAlbum photoAlbum = photoAlbumRepository.findById(photoAlbumId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PHOTOALBUM_NOT_FOUND));
+
+        Member member = photoAlbum.getAmateurShow().getMember();
+
+        List<Image> images = imageRepository.findAllByFilePathAndContentId(FilePath.photoAlbum, photoAlbumId);
+        images.forEach(image -> imageService.deleteImage(image.getId(), member.getId() ));
+
+        photoAlbumRepository.delete(photoAlbum);
+
+        return "관리자 권한으로 삭제가 완료되었습니다.";
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminPhotoAlbumResponseDTO.SimplePhotoAlbumDTO> searchPhotoAlbum(String keyword){
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<PhotoAlbum> results = photoAlbumRepository.searchPhotoAlbumByKeyword(keyword);
+        return results.stream()
+                .map(photoAlbum -> AdminPhotoAlbumResponseDTO.SimplePhotoAlbumDTO.builder()
+                        .id(photoAlbum.getId())
+                        .amateurShowName(photoAlbum.getAmateurShow().getName())
+                        .uploaderId(photoAlbum.getAmateurShow().getMember().getId())
+                        .uploaderName(photoAlbum.getAmateurShow().getMember().getName())
+                        .updatedAt(photoAlbum.getUpdatedAt())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/cc/backend/config/jwt/CustomUserDetails.java
+++ b/src/main/java/cc/backend/config/jwt/CustomUserDetails.java
@@ -25,7 +25,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority(member.getRole().name()));
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + member.getRole().name()));
     }
 
     @Override

--- a/src/main/java/cc/backend/photoAlbum/repository/PhotoAlbumRepository.java
+++ b/src/main/java/cc/backend/photoAlbum/repository/PhotoAlbumRepository.java
@@ -2,6 +2,8 @@ package cc.backend.photoAlbum.repository;
 
 import cc.backend.photoAlbum.entity.PhotoAlbum;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +12,12 @@ import java.util.List;
 public interface PhotoAlbumRepository extends JpaRepository<PhotoAlbum, Long> {
     List<PhotoAlbum> findAllByAmateurShowId(Long amateurShowId);
     List<PhotoAlbum> findAllByOrderByUpdatedAtDesc();
+    @Query("""
+        SELECT p FROM PhotoAlbum p
+        WHERE CAST(p.id AS string) LIKE %:keyword%
+           OR CAST(p.amateurShow.id AS string) LIKE %:keyword%
+           OR p.amateurShow.name LIKE %:keyword%
+           OR p.content LIKE %:keyword%
+    """)
+    List<PhotoAlbum> searchPhotoAlbumByKeyword(@Param("keyword") String keyword);
 }


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - 사진첩 전체조회
    - 사진첩 상세조회
    - 사진첩 관리(피그마에서 가리기가 아니라 삭제라네요..)
    - 사진첩 검색
    - controller 에서 PreAuthorize("hasRole')로 헤더 검증이 작동 안 해서  getAuthorities 반환 시에 ROLE_ 추가로 해결했습니다.
  
3. **📸 스크린샷 (선택)**
    -
<img width="635" height="739" alt="image" src="https://github.com/user-attachments/assets/a6d32b48-a9d9-401d-b628-185ee55da3ed" />

4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"
