### PR TITLE
[FEAT] 알림센터 무한스크롤 추가, s3 이미지 삭제로직 수정

### DIFF
--- a/src/main/java/cc/backend/config/s3/S3Service.java
+++ b/src/main/java/cc/backend/config/s3/S3Service.java
@@ -86,26 +86,27 @@ public class S3Service {
     }
 
     public void deleteFile(String keyName, Long memberId) {
+        // 회원 검증
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
 
-        memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
-
-        if(doesObjectExist(keyName, memberId)) {
-            try {
-                DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
-                        .bucket(bucket2)
-                        .key(keyName)
-                        .build();
-
-                s3Client.deleteObject(deleteObjectRequest);
-                log.info("Deleted file from S3: {}", keyName);
-            } catch (Exception e) {
-                log.error("Failed to delete file from S3: {}", keyName, e);
-                throw new RuntimeException("파일 삭제 실패: " + e.getMessage());
-            }
-
+        // S3에 존재하는지 확인
+        if (!doesObjectExist(keyName, memberId)) {
+            throw new GeneralException(ErrorStatus.NOT_FOUND_IN_S3);
         }
-        throw new RuntimeException("해당 파일이 S3에 존재하지 않음");
 
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket2)
+                    .key(keyName)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("Deleted file from S3: {}", keyName);
+        } catch (Exception e) {
+            log.error("Failed to delete file from S3: {}", keyName, e);
+            throw new RuntimeException("파일 삭제 실패: " + e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/cc/backend/notice/controller/MemberNoticeController.java
+++ b/src/main/java/cc/backend/notice/controller/MemberNoticeController.java
@@ -8,9 +8,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -26,8 +28,13 @@ public class MemberNoticeController {
             "type이 HOT, COMMENT 일 경우 contentId는 BoardId," +
             "type이 REPLY 일 경우 contentId는 CommentId" +
             "type이 TICKET 일 경우 contentId는 TicketId")
-    public ApiResponse<List<MemberNoticeResponseDTO.MemberNoticeDTO>> getAllMemberNotice(@AuthenticationPrincipal(expression = "member") Member member){
-        return ApiResponse.onSuccess(memberNoticeService.getAllMemberNotice(member.getId()));
+    public ApiResponse<MemberNoticeResponseDTO.MemberNoticeListDTO> getAllMemberNotice(
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorCreatedAt,
+            @RequestParam(defaultValue = "10") int size) {
+        return ApiResponse.onSuccess(memberNoticeService.getAllMemberNotice(member.getId(), cursorId, cursorCreatedAt, size));
     }
 
     @PatchMapping("/{noticeId}")

--- a/src/main/java/cc/backend/notice/dto/MemberNoticeResponseDTO.java
+++ b/src/main/java/cc/backend/notice/dto/MemberNoticeResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,6 +23,27 @@ public class MemberNoticeResponseDTO {
         private Long contentId;
         private Boolean isRead;
         private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MemberNoticeListDTO {
+        private Meta meta;
+        private List<MemberNoticeDTO> items;
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class Meta {
+            private int count;
+            private boolean empty;
+            private boolean hasNext;
+            private Long nextCursorId;
+            private LocalDateTime nextCursorCreatedAt;
+        }
 
     }
 }

--- a/src/main/java/cc/backend/notice/repository/MemberNoticeRepository.java
+++ b/src/main/java/cc/backend/notice/repository/MemberNoticeRepository.java
@@ -1,13 +1,32 @@
 package cc.backend.notice.repository;
 
 import cc.backend.notice.entity.MemberNotice;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface MemberNoticeRepository extends JpaRepository<MemberNotice, Long> {
-    List<MemberNotice> findAllByMemberIdAndIsReadOrderByCreatedAtDesc(Long memberId, boolean isRead);
+    List<MemberNotice> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
+    @Query("""
+        SELECT mn
+        FROM MemberNotice mn
+        WHERE mn.member.id = :memberId
+          AND (:cursorCreatedAt IS NULL 
+            OR mn.createdAt < :cursorCreatedAt 
+            OR (mn.createdAt = :cursorCreatedAt AND mn.id < :cursorId))
+        ORDER BY mn.createdAt DESC, mn.id DESC
+    """)
+    List<MemberNotice> findMemberNoticeByCursor(
+            @Param("memberId") Long memberId,
+            @Param("cursorId") Long cursorId,
+            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+            Pageable pageable
+    );
 
 }

--- a/src/main/java/cc/backend/notice/service/MemberNoticeService.java
+++ b/src/main/java/cc/backend/notice/service/MemberNoticeService.java
@@ -5,13 +5,11 @@ import cc.backend.apiPayLoad.exception.GeneralException;
 import cc.backend.member.entity.Member;
 import cc.backend.member.repository.MemberRepository;
 import cc.backend.notice.dto.MemberNoticeResponseDTO;
-import cc.backend.notice.dto.NoticeResponseDTO;
 import cc.backend.notice.entity.MemberNotice;
-import cc.backend.notice.entity.enums.NoticeType;
 import cc.backend.notice.repository.MemberNoticeRepository;
 import cc.backend.notice.repository.NoticeRepository;
-import jakarta.xml.bind.SchemaOutputResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,21 +24,51 @@ public class MemberNoticeService {
     private final NoticeRepository noticeRepository;
     private final MemberRepository memberRepository;
 
-    public List<MemberNoticeResponseDTO.MemberNoticeDTO> getAllMemberNotice(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(()->new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    public MemberNoticeResponseDTO.MemberNoticeListDTO getAllMemberNotice(
+            Long memberId, Long cursorId, LocalDateTime cursorCreatedAt, int pageSize) {
 
-        List<MemberNotice> memberNotices = memberNoticeRepository.findAllByMemberIdAndIsReadOrderByCreatedAtDesc(memberId, false);
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        return memberNotices.stream().map(memberNotice -> MemberNoticeResponseDTO.MemberNoticeDTO.builder()
-                .id(memberNotice.getId())
-                .noticeType(memberNotice.getNotice().getType())
-                .message(memberNotice.getNotice().getMessage())
-                .isRead(memberNotice.getIsRead())
-                .contentId(memberNotice.getNotice().getContentId())
-                .createdAt(memberNotice.getCreatedAt())
-                .build())
+        List<MemberNotice> memberNotices =
+                memberNoticeRepository.findMemberNoticeByCursor(
+                        memberId,
+                        cursorId,
+                        cursorCreatedAt,
+                        PageRequest.of(0, pageSize + 1));
+
+        boolean hasNext = memberNotices.size() > pageSize;
+
+        List<MemberNotice> limited = memberNotices.stream()
+                .limit(pageSize)
                 .toList();
+
+        List<MemberNoticeResponseDTO.MemberNoticeDTO> items = limited.stream()
+                .map(notice -> MemberNoticeResponseDTO.MemberNoticeDTO.builder()
+                        .id(notice.getId())
+                        .noticeType(notice.getNotice().getType())
+                        .message(notice.getNotice().getMessage())
+                        .isRead(notice.getIsRead())
+                        .contentId(notice.getNotice().getContentId())
+                        .createdAt(notice.getCreatedAt())
+                        .build())
+                .toList();
+
+
+        Long nextCursorId = hasNext ? limited.get(limited.size() - 1).getId() : null;
+        LocalDateTime nextCursorCreatedAt = hasNext ? limited.get(limited.size() - 1).getCreatedAt() : null;
+
+
+        return MemberNoticeResponseDTO.MemberNoticeListDTO.builder()
+                .items(items)
+                .meta(MemberNoticeResponseDTO.MemberNoticeListDTO.Meta.builder()
+                        .count(items.size())
+                        .hasNext(hasNext)
+                        .empty(items.isEmpty())
+                        .nextCursorId(nextCursorId)
+                        .nextCursorCreatedAt(nextCursorCreatedAt)
+                        .build())
+                .build();
     }
 
     @Transactional
@@ -66,5 +94,4 @@ public class MemberNoticeService {
                 .createdAt(memberNotice.getCreatedAt())
                 .build();
     }
-
 }


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - isRead=false 안 읽은 알림만 보여주던 문제 해결
    - createdAt 기준 커서 기반 무한스크롤 추가(tie-breaker 는 id) 
    - 알림 반환 dto wrapper(meta+items) 형태로 수정
    - s3 Service deleteFIle 메서드 오류 슈정
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"
