### PR TITLE
[FIX] photoAlbum 삭제시 amateurShow 삭제 문제 해결

### DIFF
--- a/src/main/java/cc/backend/admin/photoAlbum/dto/AdminPhotoAlbumResponseDTO.java
+++ b/src/main/java/cc/backend/admin/photoAlbum/dto/AdminPhotoAlbumResponseDTO.java
@@ -30,13 +30,15 @@ public class AdminPhotoAlbumResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DetailPhotoAlbumDTO {
-        private Long id;
+        private Long photoAlbumId;
         private Long amateurShowId;
         private String amateurShowName;
         private Long uploaderId;
         private String uploaderName;
         private String content;
         private LocalDateTime updatedAt;
+        private List<ImageResponseDTO.ImageResultDTO> imageResultDTOs;
+
     }
 
 

--- a/src/main/java/cc/backend/admin/photoAlbum/service/AdminPhotoAlbumService.java
+++ b/src/main/java/cc/backend/admin/photoAlbum/service/AdminPhotoAlbumService.java
@@ -3,6 +3,7 @@ package cc.backend.admin.photoAlbum.service;
 import cc.backend.admin.photoAlbum.dto.AdminPhotoAlbumResponseDTO;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.image.DTO.ImageResponseDTO;
 import cc.backend.image.FilePath;
 import cc.backend.image.entity.Image;
 import cc.backend.image.repository.ImageRepository;
@@ -50,14 +51,27 @@ public class AdminPhotoAlbumService {
         PhotoAlbum photoAlbum = photoAlbumRepository.findById(photoAlbumId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus.PHOTOALBUM_NOT_FOUND));
 
+        List<Image> images = imageRepository.findAllByFilePathAndContentId(FilePath.photoAlbum, photoAlbumId);
+
+        List<ImageResponseDTO.ImageResultDTO> imageResultDTOs = images.stream()
+                .map(image -> ImageResponseDTO.ImageResultDTO.builder()
+                        .id(image.getId())
+                        .keyName(image.getKeyName())
+                        .imageUrl(image.getImageUrl())
+                        .filePath(image.getFilePath())
+                        .contentId(image.getContentId())
+                        .uploadedAt(image.getUploadedAt())
+                        .build()).toList();
+
         return AdminPhotoAlbumResponseDTO.DetailPhotoAlbumDTO.builder()
-                .id(photoAlbum.getId())
+                .photoAlbumId(photoAlbum.getId())
                 .amateurShowId(photoAlbum.getAmateurShow().getId())
                 .amateurShowName(photoAlbum.getAmateurShow().getName())
                 .content(photoAlbum.getContent())
                 .uploaderId(photoAlbum.getAmateurShow().getMember().getId())
                 .uploaderName(photoAlbum.getAmateurShow().getMember().getName())
                 .updatedAt(photoAlbum.getUpdatedAt())
+                .imageResultDTOs(imageResultDTOs)
                 .build();
     }
 

--- a/src/main/java/cc/backend/amateurShow/converter/AmateurConverter.java
+++ b/src/main/java/cc/backend/amateurShow/converter/AmateurConverter.java
@@ -43,6 +43,7 @@ public class AmateurConverter {
         return AmateurEnrollResponseDTO.AmateurEnrollResult.builder()
                 .amateurShowId(amateurShow.getId())
                 .name(amateurShow.getName())
+                .memberId(amateurShow.getMember().getId())
                 .build();
     }
 
@@ -217,6 +218,7 @@ public class AmateurConverter {
                 .collect(Collectors.toList());
 
         return AmateurShowResponseDTO.AmateurShowResult.builder()
+                .memberId(amateurShow.getMember().getId())
                 .amateurShowId(amateurShow.getId())
                 .name(amateurShow.getName())
                 .performerName(amateurShow.getPerformerName())

--- a/src/main/java/cc/backend/amateurShow/dto/AmateurEnrollResponseDTO.java
+++ b/src/main/java/cc/backend/amateurShow/dto/AmateurEnrollResponseDTO.java
@@ -14,5 +14,6 @@ public class AmateurEnrollResponseDTO {
     public static class AmateurEnrollResult{
         private Long amateurShowId; // 소극장 공연 id
         private String name; // 공연 이름
+        private Long memberId; //등록자 id
     }
 }

--- a/src/main/java/cc/backend/amateurShow/dto/AmateurShowResponseDTO.java
+++ b/src/main/java/cc/backend/amateurShow/dto/AmateurShowResponseDTO.java
@@ -16,6 +16,7 @@ public class AmateurShowResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class AmateurShowResult{ // 소극장 공연 단건 조회용
+        private Long memberId; //등록자 memberId
         private Long amateurShowId; // 소극장 공연 id
         private String name; // 공연 이름
         private String performerName; // 공연진 이름

--- a/src/main/java/cc/backend/amateurShow/entity/AmateurShow.java
+++ b/src/main/java/cc/backend/amateurShow/entity/AmateurShow.java
@@ -69,7 +69,7 @@ public class AmateurShow extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany (mappedBy = "amateurShow", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany (mappedBy = "amateurShow", cascade = CascadeType.PERSIST)
     private List<PhotoAlbum> photoAlbums = new ArrayList<>();
 
     @OneToMany(mappedBy = "amateurShow", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/cc/backend/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/cc/backend/notice/service/NoticeServiceImpl.java
@@ -126,7 +126,7 @@ public class NoticeServiceImpl implements NoticeService {
         Notice newNotice = noticeRepository.save(
                 Notice.builder()
                         .type(NoticeType.AMATEURSHOW)
-                        .message("소극장 공연 " + '"' + amateurShow.getName() + '"' + " 등록 완료! 소극장 공연 페이지에서 확인해보세요!")
+                        .message("소극장 공연 " + "'" + amateurShow.getName() + "'" + " 등록 완료! 소극장 공연 페이지에서 확인해보세요!")
                         .contentId(amateurShowId)
                         .build()
         );
@@ -199,7 +199,7 @@ public class NoticeServiceImpl implements NoticeService {
 
         Notice notice = noticeRepository.save(Notice.builder()
                 .type(NoticeType.TICKET)
-                .message("'" + event.getAmateurShow().getName() + '"' + " 공연 예약이 완료되었습니다.")
+                .message("'" + event.getAmateurShow().getName() + "'" + " 공연 예약이 완료되었습니다.")
                 .contentId(event.getAmateurTicket().getId())
                 .build()
         );
@@ -224,7 +224,7 @@ public class NoticeServiceImpl implements NoticeService {
     public NoticeResponseDTO.NoticeDTO notifyApproval(ApproveShowEvent event) {
         Notice notice = noticeRepository.save(Notice.builder()
                 .type(NoticeType.AMATEURSHOW)
-                .message("요청하신" + "'" + event.getAmateurShow().getName() + '"'+ "공연 등록이 승인되었습니다.")
+                .message("요청하신" + "'" + event.getAmateurShow().getName() + "'"+ "공연 등록이 승인되었습니다.")
                 .contentId(event.getAmateurShow().getId())
                 .build()
         );
@@ -249,7 +249,7 @@ public class NoticeServiceImpl implements NoticeService {
     public NoticeResponseDTO.NoticeDTO notifyRejection(RejectShowEvent event){
         Notice notice = noticeRepository.save(Notice.builder()
                 .type(NoticeType.AMATEURSHOW)
-                .message("요청하신" + "'" + event.getAmateurShow().getName() + '"'+ "공연 등록이 반려되었습니다." + "\n"
+                .message("요청하신" + "'" + event.getAmateurShow().getName() + "'" + "공연 등록이 반려되었습니다." + "\n"
                         + event.getAmateurShow().getRejectReason())
                 .contentId(event.getAmateurShow().getId())
                 .build()

--- a/src/main/java/cc/backend/photoAlbum/entity/PhotoAlbum.java
+++ b/src/main/java/cc/backend/photoAlbum/entity/PhotoAlbum.java
@@ -24,7 +24,7 @@ public class PhotoAlbum extends BaseEntity {
 
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "amateur_show_id")
     private AmateurShow amateurShow;
 


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - AmateurShow 엔티티 내 photoAlbums 필드 orphanRemoval 수정
    - PhotoAlbum cascade 설정 수정
    - 프론트 요청으로 amateurShow 반환 DTO에 memberId 필드 추가
    - 관리자 사진첩 조회에 이미지 다 보이도록 수정
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"
