### PR TITLE
[Hotfix/96]게시판 내 Image 엔티티 참조 제거

### DIFF
--- a/src/main/java/cc/backend/admin/board/dto/response/AdminBoardDetailResponse.java
+++ b/src/main/java/cc/backend/admin/board/dto/response/AdminBoardDetailResponse.java
@@ -31,13 +31,7 @@ public class AdminBoardDetailResponse {
     private List<String> imgUrls;
     private String specialMessage; // soft delete 메시지용
 
-    public static AdminBoardDetailResponse from(Board board) {
-        List<String> imageUrls = board.getImages() != null ?
-                board.getImages().stream()
-                        .map(Image::getImageUrl)
-                        .collect(Collectors.toList()) :
-                new ArrayList<>();
-
+    public static AdminBoardDetailResponse of(Board board, List<String> imgUrls) {
         return AdminBoardDetailResponse.builder()
                 .boardId(board.getId())
                 .title(board.getTitle())
@@ -50,7 +44,7 @@ public class AdminBoardDetailResponse {
                 .createdAt(board.getCreatedAt())
                 .updatedAt(board.getUpdatedAt())
                 .isDeleted(board.isDeleted())
-                .imgUrls(imageUrls)
+                .imgUrls(imgUrls)
                 .specialMessage(board.isDeleted() ?
                         "soft delete 게시물입니다. 자세한건 DB를 참고해주세요" : null)
                 .build();

--- a/src/main/java/cc/backend/admin/board/service/AdminBoardService.java
+++ b/src/main/java/cc/backend/admin/board/service/AdminBoardService.java
@@ -12,6 +12,9 @@ import cc.backend.board.entity.enums.ReportTarget;
 import cc.backend.board.repository.BoardRepository;
 import cc.backend.board.repository.CommentRepository;
 import cc.backend.board.service.CommentService;
+import cc.backend.image.FilePath;
+import cc.backend.image.entity.Image;
+import cc.backend.image.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -31,6 +35,7 @@ public class AdminBoardService {
     private final BoardRepository boardRepository;
     private final CommentService commentService;
     private final CommentRepository commentRepository;
+    private final ImageRepository imageRepository;
 
     //게시글 목록 조회
     @Transactional(readOnly = true)
@@ -48,7 +53,15 @@ public class AdminBoardService {
         Board board = boardRepository.findByIdIncludingDeleted(boardId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOARD_NOT_FOUND));
 
-        AdminBoardDetailResponse boardDetail = AdminBoardDetailResponse.from(board);
+
+        // 상세 조회에서는 모든 이미지 조회
+        List<String> imgUrls = imageRepository.findAllByFilePathAndContentId(FilePath.board, boardId)
+                .stream()
+                .map(Image::getImageUrl)
+                .collect(Collectors.toList());
+
+        AdminBoardDetailResponse boardDetail = AdminBoardDetailResponse.of(board, imgUrls);
+
 
         // 댓글 목록 조회
         List<CommentResponse> comments = new ArrayList<>();

--- a/src/main/java/cc/backend/board/dto/response/BoardListResponse.java
+++ b/src/main/java/cc/backend/board/dto/response/BoardListResponse.java
@@ -28,8 +28,8 @@ public class BoardListResponse {
     @Schema(description = "게시글 내용", example = "게시글 내용입니다. 반갑습니다!")
     private String content;
 
-    @Schema(description = "첨부 이미지 URL 목록")
-    private List<String> imgUrls;
+    @Schema(description = "대표 이미지 URL")
+    private String imgUrl;
 
     @Schema(description = "좋아요 수", example = "5")
     private int likeCount;
@@ -49,7 +49,7 @@ public class BoardListResponse {
     @Schema(description = "수정일시", example = "2024-01-15T14:20:00")
     private LocalDateTime updatedAt;
 
-    public static BoardListResponse from(Board board) {
+    public static BoardListResponse of(Board board, String firstImageUrl) {
         String writer;
         if (board.getBoardType() == BoardType.PROMOTION) {
             writer = board.getMember().getUsername();
@@ -57,17 +57,12 @@ public class BoardListResponse {
             writer = "익명";
         }
 
-        // 연관관계(이미지 엔티티)에서 이미지 URL 조회
-        List<String> imgUrls = board.getImages().stream()
-                .map(Image::getImageUrl)
-                .collect(Collectors.toList());
-
         return BoardListResponse.builder()
                 .boardId(board.getId())
                 .boardType(board.getBoardType())
                 .title(board.getTitle())
                 .content(board.getContent())
-                .imgUrls(imgUrls)
+                .imgUrl(firstImageUrl)
                 .likeCount(board.getLikeCount())
                 .commentCount(board.getCommentCount())
                 .memberId(board.getMember().getId())

--- a/src/main/java/cc/backend/board/entity/Board.java
+++ b/src/main/java/cc/backend/board/entity/Board.java
@@ -44,9 +44,9 @@ public class Board extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @Where(clause = "file_path = 'board'")
-    private List<Image> images = new ArrayList<>();
+//    @OneToMany(fetch = FetchType.LAZY)
+//    @Where(clause = "file_path = 'board'")
+//    private List<Image> images = new ArrayList<>();
 
     @Builder.Default
     @Column(nullable = false)

--- a/src/main/java/cc/backend/board/entity/Board.java
+++ b/src/main/java/cc/backend/board/entity/Board.java
@@ -39,14 +39,9 @@ public class Board extends BaseEntity {
 
     private int commentCount = 0;
 
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
-//    @OneToMany(fetch = FetchType.LAZY)
-//    @Where(clause = "file_path = 'board'")
-//    private List<Image> images = new ArrayList<>();
 
     @Builder.Default
     @Column(nullable = false)

--- a/src/main/java/cc/backend/board/service/BoardService.java
+++ b/src/main/java/cc/backend/board/service/BoardService.java
@@ -36,10 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -129,8 +126,9 @@ public class BoardService {
             updateBoardImages(board, dto.getImageRequestDTOs(), memberId);
         }
 
-        // 수정된 이미지 URL 목록 조회- imageUrl 필드 관련 수정필요
-        List<String> updatedImgUrls = board.getImages().stream()
+        // 수정된 이미지 URL 목록 조회
+        List<String> updatedImgUrls = imageRepository.findAllByFilePathAndContentId(FilePath.board, boardId)
+                .stream()
                 .map(Image::getImageUrl)
                 .collect(Collectors.toList());
 
@@ -170,7 +168,18 @@ public class BoardService {
     public Slice<BoardListResponse> getBoards(BoardType boardType, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
         Slice<Board> boardSlice = boardRepository.findAllByBoardTypeOrderByIdDesc(boardType, pageable);
-        return boardSlice.map(BoardListResponse::from);
+
+        // 첫 번째 이미지 배치 조회
+        Map<Long, String> firstImageMap = getFirstImageMapForBoards(
+                boardSlice.getContent().stream()
+                        .map(Board::getId)
+                        .collect(Collectors.toList())
+        );
+
+        return boardSlice.map(board -> BoardListResponse.of(
+                board,
+                firstImageMap.get(board.getId())
+        ));
     }
 
     //게시글 상세 조회
@@ -221,9 +230,20 @@ public class BoardService {
     public List<BoardListResponse> getHotBoards() {
         List<HotBoard> hotBoards = hotBoardRepository.findTop10ByOrderByBoard_CreatedAtDesc();
         // 등록일 순으로 정렬
-        return hotBoards.stream()
+        List<Board> boards = hotBoards.stream()
                 .sorted(Comparator.comparing(hb -> hb.getBoard().getCreatedAt()))
-                .map(hb -> BoardListResponse.from(hb.getBoard()))
+                .map(HotBoard::getBoard)
+                .collect(Collectors.toList());
+
+        // 첫 번째 이미지 배치 조회
+        Map<Long, String> firstImageMap = getFirstImageMapForBoards(
+                boards.stream()
+                        .map(Board::getId)
+                        .collect(Collectors.toList())
+        );
+
+        return boards.stream()
+                .map(board -> BoardListResponse.of(board, firstImageMap.get(board.getId())))
                 .collect(Collectors.toList());
     }
 
@@ -260,7 +280,16 @@ public class BoardService {
             }
         }
 
-        return boardSlice.map(BoardListResponse::from);
+        Map<Long, String> firstImageMap = getFirstImageMapForBoards(
+                boardSlice.getContent().stream()
+                        .map(Board::getId)
+                        .collect(Collectors.toList())
+        );
+
+        return boardSlice.map(board -> BoardListResponse.of(
+                board,
+                firstImageMap.get(board.getId())
+        ));
     }
 
     //내가 쓴 게시글 리스트 조회
@@ -270,7 +299,16 @@ public class BoardService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
         Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
         Slice<Board> boardSlice = boardRepository.findAllByMemberIdOrderByIdDesc(member.getId(), pageable);
-        return boardSlice.map(BoardListResponse::from);
+        Map<Long, String> firstImageMap = getFirstImageMapForBoards(
+                boardSlice.getContent().stream()
+                        .map(Board::getId)
+                        .collect(Collectors.toList())
+        );
+
+        return boardSlice.map(board -> BoardListResponse.of(
+                board,
+                firstImageMap.get(board.getId())
+        ));
     }
 
     // --------------- 내부 메서드 ------------
@@ -340,5 +378,23 @@ public class BoardService {
         if (!toAdd.isEmpty()) {
             imageService.saveImages(memberId, toAdd);
         }
+    }
+
+    //첫번 째 이미지만 조회 (N+1 문제 고려)
+    private Map<Long, String> getFirstImageMapForBoards(List<Long> boardIds) {
+        if (boardIds == null || boardIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // 배치로 첫 번째 이미지 조회
+        List<Image> firstImages = imageRepository.findFirstByContentIds(boardIds, FilePath.board);
+
+        // contentId를 키로, imageUrl을 값으로 하는 Map 생성
+        return firstImages.stream()
+                .collect(Collectors.toMap(
+                        Image::getContentId,
+                        Image::getImageUrl,
+                        (existing, replacement) -> existing // 중복 키가 있으면 기존 값 유지
+                ));
     }
 }


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - #96 
2. **📝 작업 내용**
    - 게시판 내 Image 엔티티 참조 -> 제거 (직접 참조)
    - 게시글 조회시 썸네일 이미지만 응답하도록 수정
