### PR TITLE
[FEAT] 관리자 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/cc/backend/admin/adminMyPage/component/AdminInitializer.java
+++ b/src/main/java/cc/backend/admin/adminMyPage/component/AdminInitializer.java
@@ -1,34 +1,39 @@
-//package cc.backend.admin.adminMyPage.component;
-//
-//import cc.backend.member.entity.Member;
-//import cc.backend.member.repository.MemberRepository;
-//import lombok.*;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.boot.ApplicationArguments;
-//import org.springframework.boot.ApplicationRunner;
-//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-//import org.springframework.stereotype.Component;
-//
-//@Slf4j
-//@Component
-//@RequiredArgsConstructor
-//public class AdminInitializer implements ApplicationRunner {
-//
-//    private final MemberRepository memberRepository;
-//    private final BCryptPasswordEncoder bCryptPasswordEncoder;
-//
-//    @Override
-//    public void run(ApplicationArguments args) throws Exception {
-//        if (memberRepository.count() == 0) {
-//            log.info("관리자 계정이 없기 때문에, 관리자를 하나 생성함");
-//            Member initialAdmin = Member.builder()
-//                    .username("CC_admin")
-//                    .password(bCryptPasswordEncoder.encode("ccadmin0520!"))
-//                    .build();
-//
-//            memberRepository.save(initialAdmin);
-//            log.info("관리자 계정 생성 완, id : {}", initialAdmin.getId());
-//
-//        }
-//    }
-//}
+package cc.backend.admin.adminMyPage.component;
+
+import cc.backend.member.entity.Member;
+import cc.backend.member.enumerate.Role;
+import cc.backend.member.repository.MemberRepository;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdminInitializer implements ApplicationRunner {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+
+        boolean hasAdmin = memberRepository.existsByRole(Role.ADMIN);
+        if (!hasAdmin) {
+            log.info("관리자 계정이 없기 때문에, 임시 관리자를 하나 생성함");
+            Member initialAdmin = Member.builder()
+                    .username("CC_admin")
+                    .name("임시 관리자")
+                    .role(Role.ADMIN)
+                    .password(bCryptPasswordEncoder.encode("12345678"))
+                    .build();
+
+            memberRepository.save(initialAdmin);
+            log.info("관리자 계정 생성 완, id : {}", initialAdmin.getId());
+
+        }
+    }
+}

--- a/src/main/java/cc/backend/admin/adminMyPage/component/AdminInitializer.java
+++ b/src/main/java/cc/backend/admin/adminMyPage/component/AdminInitializer.java
@@ -1,5 +1,6 @@
 package cc.backend.admin.adminMyPage.component;
 
+import org.springframework.beans.factory.annotation.Value;
 import cc.backend.member.entity.Member;
 import cc.backend.member.enumerate.Role;
 import cc.backend.member.repository.MemberRepository;
@@ -17,9 +18,13 @@ public class AdminInitializer implements ApplicationRunner {
 
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    @Value("${admin.password}")
+    private String defaultAdminPassword;
+
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
+
 
         boolean hasAdmin = memberRepository.existsByRole(Role.ADMIN);
         if (!hasAdmin) {
@@ -28,11 +33,11 @@ public class AdminInitializer implements ApplicationRunner {
                     .username("CC_admin")
                     .name("임시 관리자")
                     .role(Role.ADMIN)
-                    .password(bCryptPasswordEncoder.encode("12345678"))
+                    .password(bCryptPasswordEncoder.encode(defaultAdminPassword))
                     .build();
 
             memberRepository.save(initialAdmin);
-            log.info("관리자 계정 생성 완, id : {}", initialAdmin.getId());
+            log.info("임시 관리자 계정 생성 완, id : {}", initialAdmin.getId());
 
         }
     }

--- a/src/main/java/cc/backend/admin/adminMyPage/controller/AdminMyPageController.java
+++ b/src/main/java/cc/backend/admin/adminMyPage/controller/AdminMyPageController.java
@@ -1,34 +1,33 @@
-//package cc.backend.admin.adminMyPage.controller;
-//
-//import cc.backend.admin.adminMyPage.dto.AdminAccountDetailDTO;
-//import cc.backend.admin.adminMyPage.dto.AdminChangePasswordRequestDTO;
-//import cc.backend.admin.adminMyPage.dto.AdminChangePasswordResponseDTO;
-//import cc.backend.admin.adminMyPage.service.AdminMyPageService;
-//import cc.backend.apiPayLoad.ApiResponse;
-//import io.swagger.v3.oas.annotations.Operation;
-//import io.swagger.v3.oas.annotations.tags.Tag;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.access.prepost.PreAuthorize;
-//import org.springframework.web.bind.annotation.*;
-//
-//@RequiredArgsConstructor
-//@RestController
-//@RequestMapping("/admin")
-//@Tag(name = "관리자 소극장 티켓 관리")
-//public class AdminMyPageController {
-//
-//    public final AdminMyPageService adminMyPageService;
-//
-//    @PostMapping("/change-password")
-//    @Operation(summary = "관리자 비밀번호 변경 API")
-//    @PreAuthorize("hasRole('ADMIN')")
-//    public ApiResponse<AdminChangePasswordResponseDTO> changePassword(
-//            @RequestBody AdminChangePasswordRequestDTO requestDTO
-//    ) {
-//        return ApiResponse.onSuccess(adminMyPageService.changePassword(requestDTO));
-//    }
-//
-//
-//
-//
-//}
+package cc.backend.admin.adminMyPage.controller;
+
+import cc.backend.admin.adminMyPage.dto.AdminChangePasswordRequestDTO;
+import cc.backend.admin.adminMyPage.dto.AdminChangePasswordResponseDTO;
+import cc.backend.admin.adminMyPage.service.AdminMyPageService;
+import cc.backend.apiPayLoad.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin")
+@Tag(name = "관리자 소극장 티켓 관리")
+public class AdminMyPageController {
+
+    public final AdminMyPageService adminMyPageService;
+
+    @PostMapping("/change-password")
+    @Operation(summary = "관리자 비밀번호 변경 API")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<AdminChangePasswordResponseDTO> changePassword(
+            @RequestBody AdminChangePasswordRequestDTO requestDTO
+    ) {
+        return ApiResponse.onSuccess(adminMyPageService.changePassword(requestDTO));
+    }
+
+
+
+
+}

--- a/src/main/java/cc/backend/admin/adminMyPage/controller/AdminMyPageController.java
+++ b/src/main/java/cc/backend/admin/adminMyPage/controller/AdminMyPageController.java
@@ -1,9 +1,12 @@
 package cc.backend.admin.adminMyPage.controller;
 
+import cc.backend.admin.adminMyPage.dto.AdminAuthDTO;
 import cc.backend.admin.adminMyPage.dto.AdminChangePasswordRequestDTO;
 import cc.backend.admin.adminMyPage.dto.AdminChangePasswordResponseDTO;
 import cc.backend.admin.adminMyPage.service.AdminMyPageService;
 import cc.backend.apiPayLoad.ApiResponse;
+import cc.backend.config.jwt.dto.TokenDTO;
+import com.google.protobuf.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/admin")
-@Tag(name = "관리자 소극장 티켓 관리")
+@Tag(name = "관리자 마이페이지")
 public class AdminMyPageController {
 
     public final AdminMyPageService adminMyPageService;
@@ -27,7 +30,13 @@ public class AdminMyPageController {
         return ApiResponse.onSuccess(adminMyPageService.changePassword(requestDTO));
     }
 
-
+    @PostMapping("/login")
+    @Operation(summary = "관리자 로그인 API",
+    description = "비밀번호를 사용해 관리자 로그인을 합니다.")
+    public ApiResponse<TokenDTO> login(
+            @RequestBody AdminAuthDTO.LoginRequest dto
+            ){
+        return ApiResponse.onSuccess(adminMyPageService.login(dto));    }
 
 
 }

--- a/src/main/java/cc/backend/admin/adminMyPage/dto/AdminAuthDTO.java
+++ b/src/main/java/cc/backend/admin/adminMyPage/dto/AdminAuthDTO.java
@@ -1,0 +1,23 @@
+package cc.backend.admin.adminMyPage.dto;
+
+
+import lombok.*;
+
+public class AdminAuthDTO {
+    @Getter
+    @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class LoginRequest {
+        private String email;   // 관리자 아이디
+        private String password;   // 평문 비밀번호
+    }
+
+    @Getter @Builder @AllArgsConstructor
+    public static class LoginResponse {
+        private String accessToken;
+        private String tokenType;
+        private long   expiresIn;
+        private String username;
+        private String name;
+        private String role;
+    }
+}

--- a/src/main/java/cc/backend/admin/adminMyPage/service/AdminMyPageService.java
+++ b/src/main/java/cc/backend/admin/adminMyPage/service/AdminMyPageService.java
@@ -1,43 +1,43 @@
-//package cc.backend.admin.adminMyPage.service;
-//
-//import cc.backend.admin.adminMyPage.dto.AdminChangePasswordRequestDTO;
-//import cc.backend.admin.adminMyPage.dto.AdminChangePasswordResponseDTO;
-//import cc.backend.apiPayLoad.code.status.ErrorStatus;
-//import cc.backend.apiPayLoad.exception.GeneralException;
-//import cc.backend.member.entity.Member;
-//import cc.backend.member.repository.MemberRepository;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-//import org.springframework.stereotype.Service;
-//
-//import java.time.LocalDateTime;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class AdminMyPageService {
-//
-//    private final MemberRepository memberRepository;
-//
-//    private final BCryptPasswordEncoder bCryptPasswordEncoder;
-//
-//    public AdminChangePasswordResponseDTO changePassword(AdminChangePasswordRequestDTO requestDTO) {
-//
-//        if (!requestDTO.getNewPassword().equals(requestDTO.getCheckNewPassword())) {
-//            throw new GeneralException(ErrorStatus.PASSWORD_NOT_MATCH);
-//        }
-//
-//        Member currentAdmin = memberRepository.findByRole(Member.)
-//                .orElseThrow(() -> new GeneralException(ErrorStatus.ADMIN_NOT_FOUND)); // (ErrorStatus에 추가 필요)
-//
-//        currentAdmin.updatePassword(bCryptPasswordEncoder.encode(requestDTO.getNewPassword()));
-//
-//
-//        return AdminChangePasswordResponseDTO.builder()
-//                .adminId(currentAdmin.getId())
-//                .message("비밀번호가 성공적으로 변경되었습니다.")
-//                .changedAt(LocalDateTime.now())
-//                .build();
-//    }
-//
-//
-//}
+package cc.backend.admin.adminMyPage.service;
+
+import cc.backend.admin.adminMyPage.dto.AdminChangePasswordRequestDTO;
+import cc.backend.admin.adminMyPage.dto.AdminChangePasswordResponseDTO;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.member.entity.Member;
+import cc.backend.member.enumerate.Role;
+import cc.backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMyPageService {
+
+    private final MemberRepository memberRepository;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public AdminChangePasswordResponseDTO changePassword(AdminChangePasswordRequestDTO requestDTO) {
+
+        if (!requestDTO.getNewPassword().equals(requestDTO.getCheckNewPassword())) {
+            throw new GeneralException(ErrorStatus.PASSWORD_NOT_MATCH);
+        }
+
+        Member currentAdmin = memberRepository.findByRole(Role.ADMIN)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ADMIN_NOT_FOUND)); // (ErrorStatus에 추가 필요)
+
+        currentAdmin.updatePassword(bCryptPasswordEncoder.encode(requestDTO.getNewPassword()));
+
+
+        return AdminChangePasswordResponseDTO.builder()
+                .memberId(currentAdmin.getId())
+                .changedAt(LocalDateTime.now())
+                .build();
+    }
+
+
+}

--- a/src/main/java/cc/backend/admin/adminMyPage/service/AdminMyPageService.java
+++ b/src/main/java/cc/backend/admin/adminMyPage/service/AdminMyPageService.java
@@ -1,9 +1,12 @@
 package cc.backend.admin.adminMyPage.service;
 
+import cc.backend.admin.adminMyPage.dto.AdminAuthDTO;
 import cc.backend.admin.adminMyPage.dto.AdminChangePasswordRequestDTO;
 import cc.backend.admin.adminMyPage.dto.AdminChangePasswordResponseDTO;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.config.jwt.TokenProvider;
+import cc.backend.config.jwt.dto.TokenDTO;
 import cc.backend.member.entity.Member;
 import cc.backend.member.enumerate.Role;
 import cc.backend.member.repository.MemberRepository;
@@ -12,10 +15,14 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class AdminMyPageService {
+
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
 
     private final MemberRepository memberRepository;
 
@@ -32,12 +39,25 @@ public class AdminMyPageService {
 
         currentAdmin.updatePassword(bCryptPasswordEncoder.encode(requestDTO.getNewPassword()));
 
-
         return AdminChangePasswordResponseDTO.builder()
                 .memberId(currentAdmin.getId())
                 .changedAt(LocalDateTime.now())
                 .build();
     }
 
+    public TokenDTO login(AdminAuthDTO.LoginRequest req) {
+        Member member = memberRepository.findMemberByEmail(req.getEmail())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
+        if (member.getRole() != Role.ADMIN) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED);
+        }
+
+        if (!passwordEncoder.matches(req.getPassword(), member.getPassword())) {
+            throw new GeneralException(ErrorStatus.PASSWORD_NOT_MATCH);
+        }
+
+
+        return tokenProvider.generateTokenDto(member);
+    }
 }

--- a/src/main/java/cc/backend/config/RedisConfig.java
+++ b/src/main/java/cc/backend/config/RedisConfig.java
@@ -11,7 +11,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
-public class RedisConfig {
+public class  RedisConfig {
 
     @Value("${spring.data.redis.host}")
     private String redisHost;

--- a/src/main/java/cc/backend/config/jwt/JwtFilter.java
+++ b/src/main/java/cc/backend/config/jwt/JwtFilter.java
@@ -31,8 +31,6 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
             throws IOException, ServletException {
-        log.info(" Checking Authorization Header for Request: {}", request.getRequestURI());
-        log.info("추출 된거 헤더 : {}", request.getHeader("Authorization"));
 
 
         if (HttpMethod.OPTIONS.matches(request.getMethod())) {

--- a/src/main/java/cc/backend/config/jwt/SecurityConfig.java
+++ b/src/main/java/cc/backend/config/jwt/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                         .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers("/swagger-resources/**").permitAll()
                         .requestMatchers("/webjars/**").permitAll()
+                        .requestMatchers("/admin/login").permitAll()
 
                         .requestMatchers(HttpMethod.GET, "/photoAlbums").permitAll()
                         .requestMatchers(HttpMethod.GET, "/boards").permitAll()

--- a/src/main/java/cc/backend/config/jwt/TokenProvider.java
+++ b/src/main/java/cc/backend/config/jwt/TokenProvider.java
@@ -70,7 +70,6 @@ public class TokenProvider {
     }
     public Authentication getAuthentication(String accessToken) {
         Claims claims = parseClaims(accessToken);
-        log.info("🔍 클레임까지 옴 Claims: {}", claims);  // 여기서 claims 값을 확인
 
         String email = claims.getSubject();
 

--- a/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
+++ b/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
@@ -50,6 +50,7 @@ public class KakaoPayBusinessService {
         KakaoPayReadyResponseDTO responseDTO = kakaoPayService.ready(ticketId, partnerUserId);
 
         if (responseDTO == null) {
+            // 재고 복구
             throw new RuntimeException("카카오페이 결제 준비 응답을 받지 못했습니다.");
         }
 
@@ -95,6 +96,7 @@ public class KakaoPayBusinessService {
         KakaoPayApproveResponseDTO responseDTO = kakaoPayService.approve(tid, partnerOrderId, partnerUserId, pgToken);
 
         if (responseDTO == null) {
+            // 재고복구
             throw new RuntimeException("카카오페이 결제 승인 응답을 받지 못했습니다.");
         }
 

--- a/src/main/java/cc/backend/member/entity/Member.java
+++ b/src/main/java/cc/backend/member/entity/Member.java
@@ -141,4 +141,7 @@ public class Member extends BaseEntity {
         this.role = newRole;
     }
 
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/cc/backend/member/repository/MemberRepository.java
+++ b/src/main/java/cc/backend/member/repository/MemberRepository.java
@@ -26,4 +26,6 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByRole(Role role);
 
     boolean existsByRole(Role role);
+
+    Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/cc/backend/member/repository/MemberRepository.java
+++ b/src/main/java/cc/backend/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package cc.backend.member.repository;
 
 import cc.backend.member.entity.Member;
+import cc.backend.member.enumerate.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,8 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
 
     boolean existsByUsername(String username);
 
+
+    Optional<Member> findByRole(Role role);
+
+    boolean existsByRole(Role role);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,3 +65,5 @@ management:
     health:
       show-details: always
 
+admin:
+  password: ${DEFAULT_PW}


### PR DESCRIPTION
1. **#102**
2. **📝 작업 내용**
- TokenProvider를 사용한 관리자 전용 로그인 기능
- 실수로 관리자가 삭제 되었을 때를 대비해, 임시 관리자 발급 기능 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin login endpoint for authentication.
  * Implemented automatic admin user initialization on startup with configurable default password.
  * Enhanced admin password change functionality with validation and encoding.

* **Chores**
  * Updated security configuration to allow unauthenticated access to login endpoint.
  * Reduced logging verbosity in JWT processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->