### PR TITLE
fix: 소극장 공연 API에 PERFORMER 역할 접근 제어 추가

### DIFF
--- a/src/main/java/cc/backend/amateurShow/controller/AmateurController.java
+++ b/src/main/java/cc/backend/amateurShow/controller/AmateurController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,18 +31,21 @@ public class AmateurController {
     private final MemberService memberService;
     private final AmateurService amateurService;
 
+    @PreAuthorize("hasRole('PERFORMER')")
     @PostMapping(value = "/enroll")
     @Operation(summary = "소극장 공연 생성 API")
     public ApiResponse<AmateurEnrollResponseDTO.AmateurEnrollResult> enrollShow(@AuthenticationPrincipal(expression = "member") Member member, @Valid @RequestBody AmateurEnrollRequestDTO requestDTO) {
         return ApiResponse.onSuccess(amateurService.enrollShow(member.getId(), requestDTO));
     }
 
+    @PreAuthorize("hasRole('PERFORMER')")
     @PatchMapping("/{amateurShowId}")
     @Operation(summary = "소극장 공연 수정 API")
     public ApiResponse<AmateurEnrollResponseDTO.AmateurEnrollResult> updateShow(@AuthenticationPrincipal(expression = "member") Member member, @PathVariable Long amateurShowId, @Valid @RequestBody AmateurUpdateRequestDTO requestDTO) {
         return ApiResponse.onSuccess(amateurService.updateShow(member.getId(), amateurShowId, requestDTO));
     }
 
+    @PreAuthorize("hasRole('PERFORMER')")
     @DeleteMapping("/{amateurShowId}")
     @Operation(summary = "소극장 공연 삭제 API")
     public ApiResponse<String> deleteShow(@AuthenticationPrincipal(expression = "member") Member member, @PathVariable Long amateurShowId) {

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -64,6 +64,11 @@ public class AmateurServiceImpl implements AmateurService {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (member.getRole() != Role.PERFORMER) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_PERFORMER);
+        }
+
         AmateurShow amateurShow = AmateurConverter.toAmateurShowEntity(member, requestDTO);
         AmateurShow newAmateurShow = amateurShowRepository.save(amateurShow);
 
@@ -137,10 +142,18 @@ public class AmateurServiceImpl implements AmateurService {
     @Override
     public AmateurEnrollResponseDTO.AmateurEnrollResult updateShow(Long memberId, Long showId, AmateurUpdateRequestDTO requestDTO) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()->new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
+                .orElseThrow(()->new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (member.getRole() != Role.PERFORMER) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_PERFORMER);
+        }
 
         AmateurShow amateurShow = amateurShowRepository.findByIdWithDetails(showId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+
+        if (!amateurShow.getMember().getId().equals(memberId)) { // 다른 공연자가 수정 못하게 방지
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED);
+        }
 
         //포스터 사진 수정
         //기존 이미지 삭제
@@ -312,10 +325,19 @@ public class AmateurServiceImpl implements AmateurService {
     @Override
     public void deleteShow(Long memberId, Long amateurShowId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
+                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (member.getRole() != Role.PERFORMER) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_PERFORMER);
+        }
 
         AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+
+        if (!amateurShow.getMember().getId().equals(memberId)) { // 다른 공연자가 삭제 못하게 방지
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED);
+        }
+
         amateurShowRepository.delete(amateurShow);
 
         List<Image> images = imageRepository.findAllByFilePathAndContentId(FilePath.amateurShow, amateurShowId);


### PR DESCRIPTION
 **📝 작업 내용**
    - 소극장 공연 생성/수정/삭제 API에 PERFORMER 역할 접근 제어 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enforced role-based access: only users with the performer role can enroll, update, or delete shows.
  * Ownership enforced: only the show owner can modify or delete their show.
  * Improved error responses: clearer handling when a member or ownership is not found/authorized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->