### PR TITLE
Fix/111/kakaopay stock

### DIFF
--- a/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
+++ b/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
@@ -42,7 +42,7 @@ public class KakaoPayController {
     @Operation(summary = "카카오페이 결제 승인 (자동 호출)", description = "결제 중단 시 카카오 서버에서 cancel_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
     public ApiResponse<String> cancel(@RequestParam("partner_order_id") String partnerOrderId) {
         kakaoPayBusinessService.stopPayment(partnerOrderId);
-        return ApiResponse.onSuccess("결제가 취소되었습니다. (재고 복구 완료)");
+        return ApiResponse.onSuccess("결제가 취소되었습니다.");
     }
 
     // 결제 실패 (시간 초과 15분)
@@ -50,6 +50,6 @@ public class KakaoPayController {
     @Operation(summary = "카카오페이 결제 승인 (자동 호출)", description = "15분간 결제 미완료 시 카카오 서버에서 fail_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
     public ApiResponse<String> fail(@RequestParam("partner_order_id") String partnerOrderId) {
         kakaoPayBusinessService.stopPayment(partnerOrderId);
-        return ApiResponse.onSuccess("결제에 실패했습니다. (재고 복구 완료)");
+        return ApiResponse.onSuccess("결제에 실패했습니다.");
     }
 }

--- a/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
+++ b/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
@@ -36,4 +36,20 @@ public class KakaoPayController {
 
         return ApiResponse.onSuccess(kakaoPayBusinessService.completePayment(partnerOrderId, pgToken));
     }
+
+    // 사용자가 X버튼으로 결제 도중 취소 (환불 아님)
+    @GetMapping("/cancel")
+    @Operation(summary = "카카오페이 결제 승인 (자동 호출)", description = "결제 중단 시 카카오 서버에서 cancel_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
+    public ApiResponse<String> cancel(@RequestParam("partner_order_id") String partnerOrderId) {
+        kakaoPayBusinessService.stopPayment(partnerOrderId);
+        return ApiResponse.onSuccess("결제가 취소되었습니다. (재고 복구 완료)");
+    }
+
+    // 결제 실패 (시간 초과 15분)
+    @GetMapping("/fail")
+    @Operation(summary = "카카오페이 결제 승인 (자동 호출)", description = "15분간 결제 미완료 시 카카오 서버에서 fail_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
+    public ApiResponse<String> fail(@RequestParam("partner_order_id") String partnerOrderId) {
+        kakaoPayBusinessService.stopPayment(partnerOrderId);
+        return ApiResponse.onSuccess("결제에 실패했습니다. (재고 복구 완료)");
+    }
 }

--- a/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
+++ b/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
@@ -39,7 +39,7 @@ public class KakaoPayController {
 
     // 사용자가 X버튼으로 결제 도중 취소 (환불 아님)
     @GetMapping("/cancel")
-    @Operation(summary = "카카오페이 결제 승인 (자동 호출)", description = "결제 중단 시 카카오 서버에서 cancel_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
+    @Operation(summary = "카카오페이 결제 중단 취소 (자동 호출)", description = "결제 중단 시 카카오 서버에서 cancel_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
     public ApiResponse<String> cancel(@RequestParam("partner_order_id") String partnerOrderId) {
         kakaoPayBusinessService.stopPayment(partnerOrderId);
         return ApiResponse.onSuccess("결제가 취소되었습니다.");
@@ -47,7 +47,7 @@ public class KakaoPayController {
 
     // 결제 실패 (시간 초과 15분)
     @GetMapping("/fail")
-    @Operation(summary = "카카오페이 결제 승인 (자동 호출)", description = "15분간 결제 미완료 시 카카오 서버에서 fail_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
+    @Operation(summary = "카카오페이 결제 실패 (자동 호출)", description = "15분간 결제 미완료 시 카카오 서버에서 fail_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
     public ApiResponse<String> fail(@RequestParam("partner_order_id") String partnerOrderId) {
         kakaoPayBusinessService.stopPayment(partnerOrderId);
         return ApiResponse.onSuccess("결제에 실패했습니다.");

--- a/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
+++ b/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
@@ -41,15 +41,23 @@ public class KakaoPayController {
     @GetMapping("/cancel")
     @Operation(summary = "카카오페이 결제 중단 취소 (자동 호출)", description = "결제 중단 시 카카오 서버에서 cancel_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
     public ApiResponse<String> cancel(@RequestParam("partner_order_id") String partnerOrderId) {
-        kakaoPayBusinessService.stopPayment(partnerOrderId);
-        return ApiResponse.onSuccess("결제가 취소되었습니다.");
+        try {
+            kakaoPayBusinessService.stopPayment(partnerOrderId);
+            return ApiResponse.onSuccess("결제가 취소되었습니다.");
+        } catch (NumberFormatException e) {
+            return ApiResponse.onFailure("INVALID_ORDER_ID", "유효하지 않은 주문번호입니다.", null);
+        }
     }
 
     // 결제 실패 (시간 초과 15분)
     @GetMapping("/fail")
     @Operation(summary = "카카오페이 결제 실패 (자동 호출)", description = "15분간 결제 미완료 시 카카오 서버에서 fail_url로 자동 호출되는 API입니다. 직접 호출하지 마세요.")
     public ApiResponse<String> fail(@RequestParam("partner_order_id") String partnerOrderId) {
-        kakaoPayBusinessService.stopPayment(partnerOrderId);
-        return ApiResponse.onSuccess("결제에 실패했습니다.");
+        try {
+            kakaoPayBusinessService.stopPayment(partnerOrderId);
+            return ApiResponse.onSuccess("결제에 실패했습니다.");
+        } catch (NumberFormatException e) {
+            return ApiResponse.onFailure("INVALID_ORDER_ID", "유효하지 않은 주문번호입니다.", null);
+        }
     }
 }

--- a/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
+++ b/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
@@ -16,12 +16,14 @@ import cc.backend.ticket.service.RealTicketService;
 import cc.backend.ticket.util.CancelPolicy;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class KakaoPayBusinessService {
 
     private final MemberTicketRepository memberTicketRepository;
@@ -100,6 +102,8 @@ public class KakaoPayBusinessService {
                 throw new RuntimeException("카카오페이 결제 승인 응답을 받지 못했습니다.");
             }
         } catch(Exception e) {
+            log.error("Payment approval failed for partnerOrderId={}: {}", partnerOrderId, e.getMessage(), e);
+
             // 결제 승인 실패 시 재고 복구
             amateurRoundsRepository.increaseStock(
                 memberTicket.getAmateurRound().getId(),

--- a/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
+++ b/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
@@ -4,7 +4,6 @@ import cc.backend.amateurShow.repository.AmateurRoundsRepository;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.apiPayLoad.exception.GeneralException;
 import cc.backend.kakaoPay.dto.responseDTO.KakaoPayApproveResponseDTO;
-import cc.backend.kakaoPay.dto.responseDTO.KakaoPayCancelResponseDTO;
 import cc.backend.kakaoPay.dto.responseDTO.KakaoPayReadyResponseDTO;
 import cc.backend.ticket.dto.response.RealTicketResponseDTO;
 import cc.backend.ticket.entity.MemberTicket;
@@ -91,13 +90,26 @@ public class KakaoPayBusinessService {
 
         // 멤버를 DB에서 추적하기
         String partnerUserId = memberTicket.getMember().getId().toString();
+        KakaoPayApproveResponseDTO responseDTO;
 
-        // 카카오페이 결제 승인 API 호출
-        KakaoPayApproveResponseDTO responseDTO = kakaoPayService.approve(tid, partnerOrderId, partnerUserId, pgToken);
+        try {
+            // 카카오페이 결제 승인 API 호출
+            responseDTO = kakaoPayService.approve(tid, partnerOrderId, partnerUserId, pgToken);
 
-        if (responseDTO == null) {
-            // 재고복구
-            throw new RuntimeException("카카오페이 결제 승인 응답을 받지 못했습니다.");
+            if (responseDTO == null) {
+                throw new RuntimeException("카카오페이 결제 승인 응답을 받지 못했습니다.");
+            }
+        } catch(Exception e) {
+            // 결제 승인 실패 시 재고 복구
+            amateurRoundsRepository.increaseStock(
+                memberTicket.getAmateurRound().getId(),
+                memberTicket.getQuantity()
+            );
+
+            memberTicket.updateReservationStatus(ReservationStatus.EXPIRED);
+            memberTicketRepository.save(memberTicket);
+
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
         }
 
         // 예약 확정 및 최종 티켓 생성
@@ -163,5 +175,28 @@ public class KakaoPayBusinessService {
         realTicketService.markTicketAsCancelled(realTicket);
 
         return RealTicketResponseDTO.from(realTicket, cancelFee, cancelAmount);
+    }
+
+    // 결제 중단(취소/실패) 시 재고 복구 로직
+    public void stopPayment(String partnerOrderId) {
+
+        Long ticketId = Long.valueOf(partnerOrderId);
+
+        MemberTicket memberTicket = memberTicketRepository.findById(ticketId)
+                                                          .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_TICKET_NOT_FOUND));
+
+        // 이미 처리된 건이면 패스
+        if (memberTicket.getReservationStatus() != ReservationStatus.PENDING) {
+            return;
+        }
+
+        // 1. 재고 복구 (증가)
+        amateurRoundsRepository.increaseStock(
+            memberTicket.getAmateurRound().getId(),
+            memberTicket.getQuantity()
+        );
+
+        // 2. 티켓 상태 변경
+        memberTicket.updateReservationStatus(ReservationStatus.EXPIRED);
     }
 }

--- a/src/main/java/cc/backend/kakaoPay/service/KakaoPayService.java
+++ b/src/main/java/cc/backend/kakaoPay/service/KakaoPayService.java
@@ -64,8 +64,8 @@ public class KakaoPayService {
                 .totalAmount(memberTicket.getTotalPrice())
                 .taxFreeAmount(0)
                 .approvalUrl(approvalUrl + "?partner_order_id=" + memberTicketId)
-                .cancelUrl(cancelUrl)
-                .failUrl(failUrl)
+                .cancelUrl(cancelUrl + "?partner_order_id=" + memberTicketId)
+                .failUrl(failUrl + "?partner_order_id=" + memberTicketId)
                 .build();
 
         // post 요청 (ready)


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - #111 
2. **📝 작업 내용**
    - 준비 단계에서 실패 처리
      - 결제창에서 사용자가 결제 중단하는 경우 cancelUrl, 15분 후 시간 초과로 종료되는 경우 failUrl로 자동 리다이렉트 됨
      - 해당 URL을 Controller에서 받아, 중단된 결제에 대해 재고를 복구하고 MemberTicket의 reservationStatus를 EXPIRED로 변경하도록 처리
    - 승인 단계에서 실패 처리
      - 카카오 자동 리다이렉트 없으므로 approve 서비스 로직 내부에서 try-catch로 예외를 잡고 재고 복구 및 상태 EXPIRED 처리를 직접 수행하도록 처리

---
근데 고민은 사용자가 아예 그냥 앱 자체를 종료시켜버려서 저렇게 리다이렉트도 안되는 경우에는 결제창도 사라지고 해당 tid로는 재시도를 못해서 이런 경우는 멤버티켓이 생성된 지 몇 분동안 계속 pending 상태면 expired로 바꾸게 스케줄러를 만들어야할까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added external payment cancel/fail callbacks so users (and the payment provider) receive clear cancellation or failure responses.

* **Bug Fixes**
  * Automatically restores inventory and expires tentative orders when payments fail or are cancelled.
  * Improved error handling and logging during payment approval to ensure data consistency and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->