### PR TITLE
[FIX] Presigned url 내려줄때 contenttype필드 명시적으로 추가하는거 제거, 테스트 방해하는 로직 제거

### DIFF
--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -85,16 +85,16 @@ public class AmateurServiceImpl implements AmateurService {
                 .build();
         imageService.saveImage(memberId, fullImageRequestDTO);
 
-        // 좋아요한 멤버리스트
-        List<MemberLike> memberLikers = memberLikeRepository.findByPerformerId(memberId);
-        // 좋아요한 멤버가 한 명 이상일 때만
-        if(!memberLikers.isEmpty()) {
-            List<Member> likers = memberLikers.stream()
-                    .map(MemberLike::getLiker)
-                    .collect(Collectors.toList());
-
-            eventPublisher.publishEvent(new NewShowEvent(newAmateurShow.getId(), memberId, likers));   //공연등록 이벤트 생성
-        }
+//        // 좋아요한 멤버리스트
+//        List<MemberLike> memberLikers = memberLikeRepository.findByPerformerId(memberId);
+//        // 좋아요한 멤버가 한 명 이상일 때만
+//        if(!memberLikers.isEmpty()) {
+//            List<Member> likers = memberLikers.stream()
+//                    .map(MemberLike::getLiker)
+//                    .collect(Collectors.toList());
+//
+//            eventPublisher.publishEvent(new NewShowEvent(newAmateurShow.getId(), memberId, likers));   //공연등록 이벤트 생성
+//        }
 
         // response
         return AmateurConverter.toAmateurEnrollDTO(newAmateurShow);
@@ -131,6 +131,7 @@ public class AmateurServiceImpl implements AmateurService {
                     .memberId(memberId)
                     .build();
 
+            imageService.saveImage(memberId, fullImageRequestDTO);
         }
 
         // 티켓

--- a/src/main/java/cc/backend/config/s3/S3Service.java
+++ b/src/main/java/cc/backend/config/s3/S3Service.java
@@ -76,7 +76,6 @@ public class S3Service {
         PutObjectRequest objectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(keyName)
-                .contentType(mimeType)
                 .build();
 
         PresignedPutObjectRequest presignedRequest =
@@ -104,9 +103,10 @@ public class S3Service {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
 
-        if (keyName == null || keyName.isBlank()) {
-            throw new GeneralException(ErrorStatus.INVALID_S3_KEY);
-        }
+        //예외처리 필요-추후개발(사진 업로드할때 아무것도 안넣으면 url 필드가 비어서 get할때도 계속 에러남 - 막아두거나 따로 처리해야할듯)
+//        if (keyName == null || keyName.isBlank()) {
+//            throw new GeneralException(ErrorStatus.INVALID_S3_KEY);
+//        }
 
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)

--- a/src/main/java/cc/backend/image/entity/Image.java
+++ b/src/main/java/cc/backend/image/entity/Image.java
@@ -37,10 +37,11 @@ public class Image {
 
     // 버킷 내 디렉토리 경로 (board, photoAlbum)
     @Enumerated(EnumType.STRING)
+    @Column(length = 12, nullable = false)
     private FilePath filePath;
 
     // board 와 photoAlbum 각각의 id (매핑없이 식별용)
-    @Column(name = "content_id")
+    @Column(name = "content_id", nullable = false)
     private Long contentId;
 
     // 업로드 시간

--- a/src/main/java/cc/backend/photoAlbum/service/PhotoAlbumServiceImpl.java
+++ b/src/main/java/cc/backend/photoAlbum/service/PhotoAlbumServiceImpl.java
@@ -179,10 +179,14 @@ public class PhotoAlbumServiceImpl implements PhotoAlbumService {
     @Transactional
     public PhotoAlbumResponseDTO.PhotoAlbumResultDTO updatePhotoAlbum(Long photoAlbumId, PhotoAlbumRequestDTO.CreatePhotoAlbumDTO requestDTO, Long memberId){
         memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         PhotoAlbum photoAlbum = photoAlbumRepository.findById(photoAlbumId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PHOTOALBUM_NOT_FOUND));
+
+        if(!memberId.equals(photoAlbum.getAmateurShow().getMember().getId())) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED);
+        }
 
         AmateurShow amateurShow = amateurShowRepository.findById(requestDTO.getAmateurShowId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - 알림이벤트 생성하는 로직이 불완전해서 일단 주석처리 -> 추후 memberLike기능 테스트 시 같이 수정
    - enrollShow, uploadPhotoAlbum 직접 테스트해보며 imageRequest받는 한 필드라도 비면 doesobject나 geturl 내려줄때도 계속 invalid_s3_key 에러 뜸 -> 프론트 단에서 하나라도 꼭 첨부하도록 제약 걸던, 백엔드 단에서 빈 필드 따로 처리하던 해야할듯-논의필요 
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization validation for photo album access
  * Fixed persistence of notice images

* **Changes**
  * Added database constraints for improved data integrity
  * Adjusted event handling behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->