### PR TITLE
[FEAT] poster, notice, casting 이미지 수정, dto로 받은 공연관련 이미지의 imageUrl을 db에 저장안하던 기존 로직 수정

### DIFF
--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -79,7 +79,7 @@ public class AmateurServiceImpl implements AmateurService {
         ImageRequestDTO.PosterImageRequestDTO dto = requestDTO.getPosterImageRequestDTO();
 
         //poster 이미지는 없으면 에러
-        if(dto.getKeyName() == null){
+        if(dto.getKeyName() == null || dto.getKeyName().isBlank()){
             throw new GeneralException(ErrorStatus.INVALID_S3_KEY);
         }
 
@@ -125,8 +125,8 @@ public class AmateurServiceImpl implements AmateurService {
 
                 ImageRequestDTO.FullImageRequestDTO fullImageRequestDTO = ImageRequestDTO.FullImageRequestDTO.builder()
                         .keyName(amateurCasting.getCastingImageKeyName())
-                        .filePath(FilePath.amateurShow)
-                        .contentId(amateurShow.getId())
+                        .filePath(FilePath.casting)
+                        .contentId(amateurCasting.getId())
                         .memberId(memberId)
                         .build();
 
@@ -148,8 +148,8 @@ public class AmateurServiceImpl implements AmateurService {
             if (keyName != null && !keyName.isBlank()) {
                 ImageRequestDTO.FullImageRequestDTO fullImageRequestDTO = ImageRequestDTO.FullImageRequestDTO.builder()
                         .keyName(requestDTO.getNotice().getNoticeImageRequestDTO().getKeyName())
-                        .filePath(FilePath.amateurShow)
-                        .contentId(amateurShow.getId())
+                        .filePath(FilePath.notice)
+                        .contentId(amateurNotice.getId())
                         .memberId(memberId)
                         .build();
 
@@ -199,7 +199,7 @@ public class AmateurServiceImpl implements AmateurService {
 
         ImageRequestDTO.PosterImageRequestDTO dto = requestDTO.getPosterImageRequestDTO();
         if (dto != null && dto.getKeyName() != null && !dto.getKeyName().isBlank()) {
-            imageService.updateImage(
+            imageService.updateShowImage(
                     memberId,
                     dto.getKeyName(),
                     Optional.ofNullable(dto.getImageUrl()),
@@ -248,14 +248,16 @@ public class AmateurServiceImpl implements AmateurService {
         }
 
         //NoticeImage 수정
-        ImageRequestDTO.NoticeImageRequestDTO dto = Objects.requireNonNull(noticeDTO).getNoticeImageRequestDTO();
+        if (noticeDTO == null) return;
+
+        ImageRequestDTO.NoticeImageRequestDTO dto = noticeDTO.getNoticeImageRequestDTO();
         if (dto != null && dto.getKeyName() != null && !dto.getKeyName().isBlank()) {
-            imageService.updateImage(
+            imageService.updateShowImage(
                     amateurShow.getMember().getId(),
                     dto.getKeyName(),
                     Optional.ofNullable(dto.getImageUrl()),
-                    amateurShow.getId(),
-                    FilePath.amateurShow
+                    noticeDTO.getNoticeId(),
+                    FilePath.notice
             );
         }
     }
@@ -285,12 +287,12 @@ public class AmateurServiceImpl implements AmateurService {
             // 캐스팅 이미지 업데이트
             ImageRequestDTO.CastingImageRequestDTO castingDTO = dto.getCastingImageRequestDTO();
             if (castingDTO != null && castingDTO.getKeyName() != null && !castingDTO.getKeyName().isBlank()) {
-                imageService.updateImage(
+                imageService.updateShowImage(
                         show.getMember().getId(),
                         castingDTO.getKeyName(),
                         Optional.ofNullable(castingDTO.getImageUrl()),
-                        show.getId(),
-                        FilePath.amateurShow
+                        dto.getCastingId(),
+                        FilePath.casting
                 );
             }
         }
@@ -400,10 +402,28 @@ public class AmateurServiceImpl implements AmateurService {
             throw new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED);
         }
 
-        amateurShowRepository.delete(amateurShow);
+        //포스터 삭제
+        Image posterImg = imageRepository.findByFilePathAndContentId(FilePath.amateurShow, amateurShowId);
+        imageService.deleteImage(posterImg.getId(), memberId);
 
-        List<Image> images = imageRepository.findAllByFilePathAndContentId(FilePath.amateurShow, amateurShowId);
-        images.forEach(image -> imageService.deleteImage(image.getId(), memberId));
+        // 공지 삭제
+        if (amateurShow.getAmateurNotice() != null) {
+            Image noticeImg = imageRepository.findByFilePathAndContentId(FilePath.notice, amateurShow.getAmateurNotice().getId());
+            if (noticeImg != null) {
+                imageService.deleteImage(noticeImg.getId(), memberId);
+            }
+        }
+
+        //캐스팅 삭제
+        List<AmateurCasting> amateurCastings = amateurShow.getAmateurCastingList();
+        List<Image> castingImages = amateurCastings.stream()
+                .map(casting -> imageRepository.findByFilePathAndContentId(FilePath.casting, casting.getId()))
+                .filter(Objects::nonNull)
+                .toList();
+        castingImages.forEach(image -> imageService.deleteImage(image.getId(), memberId));
+
+        //amateurShow 삭제
+        amateurShowRepository.delete(amateurShow);
     }
 
     // 소극장 공연 단건 조회

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -143,11 +143,11 @@ public class AmateurServiceImpl implements AmateurService {
         if (amateurNotice != null) {
             amateurNoticeRepository.save(amateurNotice);
 
-            String keyName = requestDTO.getNotice().getNoticeImageRequestDTO().getKeyName();
+            ImageRequestDTO.NoticeImageRequestDTO noticeImageDTO = requestDTO.getNotice().getNoticeImageRequestDTO();
             //keyName 비었으면 스킵
-            if (keyName != null && !keyName.isBlank()) {
+            if (noticeImageDTO != null && noticeImageDTO.getKeyName() != null && !noticeImageDTO.getKeyName().isBlank()) {
                 ImageRequestDTO.FullImageRequestDTO fullImageRequestDTO = ImageRequestDTO.FullImageRequestDTO.builder()
-                        .keyName(requestDTO.getNotice().getNoticeImageRequestDTO().getKeyName())
+                        .keyName(noticeImageDTO.getKeyName())
                         .filePath(FilePath.notice)
                         .contentId(amateurNotice.getId())
                         .memberId(memberId)
@@ -156,7 +156,7 @@ public class AmateurServiceImpl implements AmateurService {
                 imageService.saveImageWithImageUrl(
                         memberId,
                         fullImageRequestDTO,
-                        Optional.ofNullable(requestDTO.getNotice().getNoticeImageRequestDTO().getImageUrl())
+                        Optional.ofNullable(noticeImageDTO.getImageUrl())
                 );
             }
         }
@@ -250,13 +250,14 @@ public class AmateurServiceImpl implements AmateurService {
         //NoticeImage 수정
         if (noticeDTO == null) return;
 
+        AmateurNotice notice = amateurShow.getAmateurNotice();
         ImageRequestDTO.NoticeImageRequestDTO dto = noticeDTO.getNoticeImageRequestDTO();
-        if (dto != null && dto.getKeyName() != null && !dto.getKeyName().isBlank()) {
+        if (notice != null && dto != null && dto.getKeyName() != null && !dto.getKeyName().isBlank()){
             imageService.updateShowImage(
                     amateurShow.getMember().getId(),
                     dto.getKeyName(),
                     Optional.ofNullable(dto.getImageUrl()),
-                    noticeDTO.getNoticeId(),
+                    notice.getId(),
                     FilePath.notice
             );
         }
@@ -272,17 +273,24 @@ public class AmateurServiceImpl implements AmateurService {
         List<AmateurCasting> updatedList = new ArrayList<>();
 
         for (AmateurUpdateRequestDTO.UpdateCasting dto : dtos) {
+            Long contentId;
+
             if (dto.getCastingId() != null && existingMap.containsKey(dto.getCastingId())) {
                 // 기존 객체 수정
                 AmateurCasting existing = existingMap.get(dto.getCastingId());
                 existing.update(dto);
                 updatedList.add(existing);
                 existingMap.remove(dto.getCastingId());
+                contentId = existing.getId();
             } else {
                 // 새 객체 추가
                 AmateurCasting newCasting = AmateurConverter.toSingleCasting(dto, show);
+                AmateurCasting savedCasting = amateurCastingRepository.save(newCasting);
                 updatedList.add(newCasting);
+
+                contentId = savedCasting.getId();
             }
+
 
             // 캐스팅 이미지 업데이트
             ImageRequestDTO.CastingImageRequestDTO castingDTO = dto.getCastingImageRequestDTO();
@@ -291,7 +299,7 @@ public class AmateurServiceImpl implements AmateurService {
                         show.getMember().getId(),
                         castingDTO.getKeyName(),
                         Optional.ofNullable(castingDTO.getImageUrl()),
-                        dto.getCastingId(),
+                        contentId,
                         FilePath.casting
                 );
             }

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -286,7 +286,7 @@ public class AmateurServiceImpl implements AmateurService {
                 // 새 객체 추가
                 AmateurCasting newCasting = AmateurConverter.toSingleCasting(dto, show);
                 AmateurCasting savedCasting = amateurCastingRepository.save(newCasting);
-                updatedList.add(newCasting);
+                updatedList.add(savedCasting);
 
                 contentId = savedCasting.getId();
             }

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -77,6 +77,12 @@ public class AmateurServiceImpl implements AmateurService {
 
         //posterImageUrl 필드는 이미 Converter에서 기입, 포스터 사진 DB에만 저장(1개만)
         ImageRequestDTO.PosterImageRequestDTO dto = requestDTO.getPosterImageRequestDTO();
+
+        //poster 이미지는 없으면 에러
+        if(dto.getKeyName() == null){
+            throw new GeneralException(ErrorStatus.INVALID_S3_KEY);
+        }
+
         ImageRequestDTO.FullImageRequestDTO fullImageRequestDTO = ImageRequestDTO.FullImageRequestDTO.builder()
                 .keyName(dto.getKeyName())
                 .filePath(FilePath.amateurShow)
@@ -111,6 +117,12 @@ public class AmateurServiceImpl implements AmateurService {
             List<AmateurCasting> amateurCastings = amateurCastingRepository.saveAll(castings);
             // 캐스팅 사진 저장(1개씩)
             amateurCastings.forEach(amateurCasting -> {
+                String keyName = amateurCasting.getCastingImageKeyName();
+                // keyName 없으면 스킵
+                if (keyName == null || keyName.isBlank()) {
+                    return;
+                }
+
                 ImageRequestDTO.FullImageRequestDTO fullImageRequestDTO = ImageRequestDTO.FullImageRequestDTO.builder()
                         .keyName(amateurCasting.getCastingImageKeyName())
                         .filePath(FilePath.amateurShow)
@@ -121,9 +133,9 @@ public class AmateurServiceImpl implements AmateurService {
                 imageService.saveImageWithImageUrl(
                         memberId,
                         fullImageRequestDTO,
-                        Optional.ofNullable(amateurCasting.getCastingImageUrl()));
-            }
-            );
+                        Optional.ofNullable(amateurCasting.getCastingImageUrl())
+                );
+            });
         }
 
         // 공지사항
@@ -131,17 +143,22 @@ public class AmateurServiceImpl implements AmateurService {
         if (amateurNotice != null) {
             amateurNoticeRepository.save(amateurNotice);
 
-            ImageRequestDTO.FullImageRequestDTO fullImageRequestDTO = ImageRequestDTO.FullImageRequestDTO.builder()
-                    .keyName(requestDTO.getNotice().getNoticeImageRequestDTO().getKeyName())
-                    .filePath(FilePath.amateurShow)
-                    .contentId(amateurShow.getId())
-                    .memberId(memberId)
-                    .build();
+            String keyName = requestDTO.getNotice().getNoticeImageRequestDTO().getKeyName();
+            //keyName 비었으면 스킵
+            if (keyName != null && !keyName.isBlank()) {
+                ImageRequestDTO.FullImageRequestDTO fullImageRequestDTO = ImageRequestDTO.FullImageRequestDTO.builder()
+                        .keyName(requestDTO.getNotice().getNoticeImageRequestDTO().getKeyName())
+                        .filePath(FilePath.amateurShow)
+                        .contentId(amateurShow.getId())
+                        .memberId(memberId)
+                        .build();
 
-            imageService.saveImageWithImageUrl(
-                    memberId,
-                    fullImageRequestDTO,
-                    Optional.ofNullable(requestDTO.getNotice().getNoticeImageRequestDTO().getImageUrl()));
+                imageService.saveImageWithImageUrl(
+                        memberId,
+                        fullImageRequestDTO,
+                        Optional.ofNullable(requestDTO.getNotice().getNoticeImageRequestDTO().getImageUrl())
+                );
+            }
         }
 
         // 티켓

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -83,18 +83,20 @@ public class AmateurServiceImpl implements AmateurService {
                 .contentId(newAmateurShow.getId())
                 .memberId(memberId)
                 .build();
-        imageService.saveImage(memberId, fullImageRequestDTO);
 
-//        // 좋아요한 멤버리스트
-//        List<MemberLike> memberLikers = memberLikeRepository.findByPerformerId(memberId);
-//        // 좋아요한 멤버가 한 명 이상일 때만
-//        if(!memberLikers.isEmpty()) {
-//            List<Member> likers = memberLikers.stream()
-//                    .map(MemberLike::getLiker)
-//                    .collect(Collectors.toList());
-//
-//            eventPublisher.publishEvent(new NewShowEvent(newAmateurShow.getId(), memberId, likers));   //공연등록 이벤트 생성
-//        }
+        imageService.saveImageWithImageUrl(memberId, fullImageRequestDTO, Optional.ofNullable(dto.getImageUrl()));
+
+
+        // 좋아요한 멤버리스트
+        List<MemberLike> memberLikers = memberLikeRepository.findByPerformerId(memberId);
+        // 좋아요한 멤버가 한 명 이상일 때만
+        if(!memberLikers.isEmpty()) {
+            List<Member> likers = memberLikers.stream()
+                    .map(MemberLike::getLiker)
+                    .collect(Collectors.toList());
+
+            eventPublisher.publishEvent(new NewShowEvent(newAmateurShow.getId(), memberId, likers));   //공연등록 이벤트 생성
+        }
 
         // response
         return AmateurConverter.toAmateurEnrollDTO(newAmateurShow);
@@ -115,8 +117,13 @@ public class AmateurServiceImpl implements AmateurService {
                         .contentId(amateurShow.getId())
                         .memberId(memberId)
                         .build();
-                imageService.saveImage(memberId, fullImageRequestDTO);
-            });
+
+                imageService.saveImageWithImageUrl(
+                        memberId,
+                        fullImageRequestDTO,
+                        Optional.ofNullable(amateurCasting.getCastingImageUrl()));
+            }
+            );
         }
 
         // 공지사항
@@ -131,7 +138,10 @@ public class AmateurServiceImpl implements AmateurService {
                     .memberId(memberId)
                     .build();
 
-            imageService.saveImage(memberId, fullImageRequestDTO);
+            imageService.saveImageWithImageUrl(
+                    memberId,
+                    fullImageRequestDTO,
+                    Optional.ofNullable(requestDTO.getNotice().getNoticeImageRequestDTO().getImageUrl()));
         }
 
         // 티켓
@@ -170,32 +180,17 @@ public class AmateurServiceImpl implements AmateurService {
             throw new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED);
         }
 
-        //포스터 사진 수정
         ImageRequestDTO.PosterImageRequestDTO dto = requestDTO.getPosterImageRequestDTO();
         if (dto != null && dto.getKeyName() != null && !dto.getKeyName().isBlank()) {
-            // 현재 포스터 이미지 조회 (show당 1개)
-            Image existingImage = imageRepository
-                    .findAllByFilePathAndContentId(FilePath.amateurShow, amateurShow.getId())
-                    .stream()
-                    .findFirst()
-                    .orElse(null);
+            imageService.updateImage(
+                    memberId,
+                    dto.getKeyName(),
+                    Optional.ofNullable(dto.getImageUrl()),
+                    amateurShow.getId(),
+                    FilePath.amateurShow
+            );
 
-            // 기존 keyName과 다르면 기존 이미지 삭제 후 교체
-            if (existingImage != null && !existingImage.getKeyName().equals(dto.getKeyName())) {
-                imageService.deleteImage(existingImage.getId(), memberId);
-            }
-
-            ImageRequestDTO.FullImageRequestDTO fullImageRequestDTO = ImageRequestDTO.FullImageRequestDTO.builder()
-                    .keyName(dto.getKeyName())
-                    .filePath(FilePath.amateurShow)
-                    .contentId(amateurShow.getId())
-                    .memberId(memberId)
-                    .build();
-
-            imageService.saveImage(memberId, fullImageRequestDTO);
-            //amateurShow 엔티티 내 posterImageUrl 필드 수정
             amateurShow.updatePosterImageUrl(dto.getImageUrl());
-
         }
 
         // 기본 정보 업데이트
@@ -234,6 +229,18 @@ public class AmateurServiceImpl implements AmateurService {
                 }
             }
         }
+
+        //NoticeImage 수정
+        ImageRequestDTO.NoticeImageRequestDTO dto = Objects.requireNonNull(noticeDTO).getNoticeImageRequestDTO();
+        if (dto != null && dto.getKeyName() != null && !dto.getKeyName().isBlank()) {
+            imageService.updateImage(
+                    amateurShow.getMember().getId(),
+                    dto.getKeyName(),
+                    Optional.ofNullable(dto.getImageUrl()),
+                    amateurShow.getId(),
+                    FilePath.amateurShow
+            );
+        }
     }
 
     private void updateCasting(AmateurShow show, List<AmateurUpdateRequestDTO.UpdateCasting> dtos) {
@@ -257,6 +264,18 @@ public class AmateurServiceImpl implements AmateurService {
                 AmateurCasting newCasting = AmateurConverter.toSingleCasting(dto, show);
                 updatedList.add(newCasting);
             }
+
+            // 캐스팅 이미지 업데이트
+            ImageRequestDTO.CastingImageRequestDTO castingDTO = dto.getCastingImageRequestDTO();
+            if (castingDTO != null && castingDTO.getKeyName() != null && !castingDTO.getKeyName().isBlank()) {
+                imageService.updateImage(
+                        show.getMember().getId(),
+                        castingDTO.getKeyName(),
+                        Optional.ofNullable(castingDTO.getImageUrl()),
+                        show.getId(),
+                        FilePath.amateurShow
+                );
+            }
         }
 
         // 삭제
@@ -267,6 +286,7 @@ public class AmateurServiceImpl implements AmateurService {
         // 최종 리스트 갱신
         show.getAmateurCastingList().clear();
         show.getAmateurCastingList().addAll(updatedList);
+
     }
 
     private void updateStaff(AmateurShow show, List<AmateurUpdateRequestDTO.UpdateStaff> dtos) {

--- a/src/main/java/cc/backend/config/s3/S3Controller.java
+++ b/src/main/java/cc/backend/config/s3/S3Controller.java
@@ -30,7 +30,7 @@ public class S3Controller {
     @GetMapping("/uploadUrl")
     public ResponseEntity<Map<String, String>> getPresignedPutUrl(
             @Parameter(description = "업로드할 이미지 파일의 확장자(jpg, jpeg, png, gif)", required = true) @RequestParam @NotBlank String imageExtension,
-            @Parameter(description = "업로드할 기능(board, photoAlbum, amateurShow)", required = true) @RequestParam FilePath filePath,
+            @Parameter(description = "업로드할 사진 종류(board, photoAlbum, amateurShow(포스터), notice, casting)", required = true) @RequestParam FilePath filePath,
             @AuthenticationPrincipal(expression = "member") Member member) {
 
         return ResponseEntity.ok(s3Service.createPresignedPutUrl(imageExtension, filePath, member.getId()));
@@ -46,7 +46,7 @@ public class S3Controller {
     public ResponseEntity<List<Map<String, String>>> getPresignedPutUrls (
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "각 이미지의 확장자 jpg, jpeg, png, gif ...", required = true) @RequestBody List<@NotBlank String> extensions,
-            @Parameter(description = "업로드할 기능(board, photoAlbum, amateurShow)", required = true) @RequestParam FilePath filePath,
+            @Parameter(description = "업로드할 기능(board, photoAlbum)", required = true) @RequestParam FilePath filePath,
             @AuthenticationPrincipal(expression = "member") Member member) {
 
         return ResponseEntity.ok(s3Service.createPresignedPutUrls(extensions, filePath, member.getId()));

--- a/src/main/java/cc/backend/config/s3/S3Controller.java
+++ b/src/main/java/cc/backend/config/s3/S3Controller.java
@@ -83,6 +83,9 @@ public class S3Controller {
     @Operation(summary = "keyName에 해당하는 파일이 S3에 실제 존재하는지 확인")
     public ResponseEntity<Boolean> doesObjectExist(@RequestParam String keyName,
                                                    @AuthenticationPrincipal(expression = "member") Member member){
+        if(keyName == null){
+            return ResponseEntity.ok(false);
+        }
         return ResponseEntity.ok(s3Service.doesObjectExist(keyName, member.getId()));
     }
 }

--- a/src/main/java/cc/backend/config/s3/S3Service.java
+++ b/src/main/java/cc/backend/config/s3/S3Service.java
@@ -65,13 +65,13 @@ public class S3Service {
             throw new GeneralException(ErrorStatus.INVALID_FILE_EXTENSION);
         }
 
-        // MIME 타입 처리 (jpg는 image/jpeg)
-        String mimeType = switch (ext) {
-            case "jpg", "jpeg" -> "image/jpeg";
-            case "png" -> "image/png";
-            case "gif" -> "image/gif";
-            default -> throw new GeneralException(ErrorStatus.INVALID_FILE_EXTENSION);
-        };
+//        // MIME 타입 처리 (jpg는 image/jpeg)
+//        String mimeType = switch (ext) {
+//            case "jpg", "jpeg" -> "image/jpeg";
+//            case "png" -> "image/png";
+//            case "gif" -> "image/gif";
+//            default -> throw new GeneralException(ErrorStatus.INVALID_FILE_EXTENSION);
+//        };
 
         PutObjectRequest objectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)

--- a/src/main/java/cc/backend/image/FilePath.java
+++ b/src/main/java/cc/backend/image/FilePath.java
@@ -1,5 +1,5 @@
 package cc.backend.image;
 
 public enum FilePath {
-    board, photoAlbum, amateurShow
+    board, photoAlbum, amateurShow, notice, casting
 }

--- a/src/main/java/cc/backend/image/service/ImageService.java
+++ b/src/main/java/cc/backend/image/service/ImageService.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 @Slf4j
 @Service
@@ -52,6 +53,30 @@ public class ImageService {
                 .contentId(requestDTO.getContentId())
                 .uploadedAt(LocalDateTime.now())
                 .memberId(memberId)
+                .build();
+
+        Image newImage = imageRepository.save(image);
+
+        return getImage(newImage.getKeyName(), memberId);
+    }
+
+    @Transactional
+    public ImageResponseDTO.ImageResultWithPresignedUrlDTO saveImageWithImageUrl(Long memberId, ImageRequestDTO.FullImageRequestDTO requestDTO, Optional<String> imageUrlOpt) {
+
+        memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        //S3에 실제 존재하는 이미지인지 검증
+        if(!s3Service.doesObjectExist(requestDTO.getKeyName(), memberId)) {
+            throw new GeneralException(ErrorStatus.NOT_FOUND_IN_S3);
+        }
+
+        String imageUrl = imageUrlOpt.orElse("");
+        Image image = Image.builder()
+                .keyName(requestDTO.getKeyName())
+                .filePath(requestDTO.getFilePath())
+                .contentId(requestDTO.getContentId())
+                .uploadedAt(LocalDateTime.now())
+                .memberId(memberId)
+                .imageUrl(imageUrl)
                 .build();
 
         Image newImage = imageRepository.save(image);
@@ -159,6 +184,45 @@ public class ImageService {
             // 로깅만 하고 예외 발생은 안 시킴
             log.error("S3 삭제 실패: {}", image.getKeyName(), e);
         }
+    }
+
+    @Transactional
+    public void updateImage(
+            Long memberId,
+            String keyName,
+            Optional<String> imageUrlOpt,
+            Long contentId,
+            FilePath filePath
+    ) {
+        if (keyName == null || keyName.isBlank()) {
+            return; // keyName 없으면 처리하지 않음
+        }
+
+        String imageUrl = imageUrlOpt.orElse("");
+
+        // 기존 이미지 조회 (filePath + contentId 기준)
+        Image existingImage = imageRepository
+                .findAllByFilePathAndContentId(filePath, contentId)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        // 기존 이미지가 있고, keyName이 다르면 삭제 후 새로 저장
+        if (existingImage != null && !existingImage.getKeyName().equals(keyName)) {
+            deleteImage(existingImage.getId(), memberId);
+        }
+
+        // 새 이미지 저장
+        Image image = Image.builder()
+                .keyName(keyName)
+                .imageUrl(imageUrl)
+                .filePath(filePath)
+                .contentId(contentId)
+                .uploadedAt(LocalDateTime.now())
+                .memberId(memberId)
+                .build();
+
+        imageRepository.save(image);
     }
 
 }

--- a/src/main/java/cc/backend/image/service/ImageService.java
+++ b/src/main/java/cc/backend/image/service/ImageService.java
@@ -56,7 +56,7 @@ public class ImageService {
             throw new GeneralException(ErrorStatus.NOT_FOUND_IN_S3);
         }
 
-        String imageUrl = imageUrlOpt.orElse("");
+        String imageUrl = imageUrlOpt.orElse(null);
         Image image = Image.builder()
                 .keyName(requestDTO.getKeyName())
                 .filePath(requestDTO.getFilePath())

--- a/src/main/java/cc/backend/image/service/ImageService.java
+++ b/src/main/java/cc/backend/image/service/ImageService.java
@@ -41,23 +41,7 @@ public class ImageService {
     @Transactional
     public ImageResponseDTO.ImageResultWithPresignedUrlDTO saveImage(Long memberId, ImageRequestDTO.FullImageRequestDTO requestDTO) {
 
-        memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        //S3에 실제 존재하는 이미지인지 검증
-        if(!s3Service.doesObjectExist(requestDTO.getKeyName(), memberId)) {
-            throw new GeneralException(ErrorStatus.NOT_FOUND_IN_S3);
-        }
-
-        Image image = Image.builder()
-                .keyName(requestDTO.getKeyName())
-                .filePath(requestDTO.getFilePath())
-                .contentId(requestDTO.getContentId())
-                .uploadedAt(LocalDateTime.now())
-                .memberId(memberId)
-                .build();
-
-        Image newImage = imageRepository.save(image);
-
-        return getImage(newImage.getKeyName(), memberId);
+        return saveImageWithImageUrl(memberId, requestDTO, Optional.empty());
     }
 
     @Transactional

--- a/src/main/java/cc/backend/image/service/ImageService.java
+++ b/src/main/java/cc/backend/image/service/ImageService.java
@@ -61,7 +61,10 @@ public class ImageService {
     }
 
     @Transactional
-    public ImageResponseDTO.ImageResultWithPresignedUrlDTO saveImageWithImageUrl(Long memberId, ImageRequestDTO.FullImageRequestDTO requestDTO, Optional<String> imageUrlOpt) {
+    public ImageResponseDTO.ImageResultWithPresignedUrlDTO saveImageWithImageUrl(
+            Long memberId,
+            ImageRequestDTO.FullImageRequestDTO requestDTO,
+            Optional<String> imageUrlOpt) {
 
         memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
         //S3에 실제 존재하는 이미지인지 검증
@@ -186,32 +189,36 @@ public class ImageService {
         }
     }
 
+    //amateurShow(poster, notice, casting) 이미지 수정
     @Transactional
-    public void updateImage(
+    public void updateShowImage(
             Long memberId,
             String keyName,
             Optional<String> imageUrlOpt,
             Long contentId,
-            FilePath filePath
-    ) {
+            FilePath filePath) {
         if (keyName == null || keyName.isBlank()) {
             return; // keyName 없으면 처리하지 않음
         }
 
-        String imageUrl = imageUrlOpt.orElse("");
+        if (!s3Service.doesObjectExist(keyName, memberId)) {
+            throw new GeneralException(ErrorStatus.NOT_FOUND_IN_S3);
+        }
+        String imageUrl = imageUrlOpt.orElse(null);
 
         // 기존 이미지 조회 (filePath + contentId 기준)
         Image existingImage = imageRepository
-                .findAllByFilePathAndContentId(filePath, contentId)
-                .stream()
-                .findFirst()
-                .orElse(null);
+                .findByFilePathAndContentId(filePath, contentId);
 
         // 기존 이미지가 있고, keyName이 다르면 삭제 후 새로 저장
-        if (existingImage != null && !existingImage.getKeyName().equals(keyName)) {
-            deleteImage(existingImage.getId(), memberId);
+        if (existingImage != null) {
+            // keyName 변경이면 S3/DB 모두 삭제
+            if (!existingImage.getKeyName().equals(keyName)) {
+                deleteImage(existingImage.getId(), memberId);}
+            else {// 같은 keyName이면 DB row만 교체(중복 방지), S3는 유지
+                imageRepository.delete(existingImage);
+            }
         }
-
         // 새 이미지 저장
         Image image = Image.builder()
                 .keyName(keyName)


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - casting, notice 이미지는 null 허용, poster는 무조건 하나 필수
    - poster, notice, casting 이미지 수정 기능 추가
    - presignedUrl 발급시 notice, casting 이미지는 다른 폴더로 올리게끔 수정
    - filePath, contentId로 이미지를 유일하게 식별가능하도록 notice, casting 분리
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors from missing or blank image keys by skipping invalid image operations and adding null-checks.
  * Ensure associated images (posters, notices, castings) are removed when deleting a show.

* **Improvements**
  * More robust image save/update flows that accept optional image URLs and properly propagate updates to posters, notices, and castings.
  * Added support for notice and casting image types across the enroll, update, and delete processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->