### PR TITLE
[FIX] 댓글 작성자에게 알림이 가는 오류 해결

### DIFF
--- a/src/main/java/cc/backend/amateurShow/controller/AmateurController.java
+++ b/src/main/java/cc/backend/amateurShow/controller/AmateurController.java
@@ -92,6 +92,6 @@ public class AmateurController {
     @GetMapping("/incoming")
     @Operation(summary = "공연 임박인 공연 조회 API")
     public ApiResponse<List<AmateurShowResponseDTO.AmateurShowList>> getShowIncoming(@AuthenticationPrincipal(expression = "member") Member member) {
-        return ApiResponse.onSuccess(amateurService.getIncomingShow(member.getId()));
+        return ApiResponse.onSuccess(amateurService.getRecentlyHotShow(member.getId()));
     }
 }

--- a/src/main/java/cc/backend/amateurShow/converter/AmateurConverter.java
+++ b/src/main/java/cc/backend/amateurShow/converter/AmateurConverter.java
@@ -156,12 +156,20 @@ public class AmateurConverter {
 
     // -- 소극장 공연 업데이트 --
     public static AmateurCasting toSingleCasting(AmateurUpdateRequestDTO.UpdateCasting dto, AmateurShow show) {
+        String imageUrl = null;
+        String keyName = null;
+
+        if (dto.getCastingImageRequestDTO() != null) {
+            imageUrl = dto.getCastingImageRequestDTO().getImageUrl();
+            keyName = dto.getCastingImageRequestDTO().getKeyName();
+        }
+
         return AmateurCasting.builder()
                 .amateurShow(show)
                 .actorName(dto.getActorName())
                 .castingName(dto.getCastingName())
-                .castingImageUrl(dto.getCastingImageRequestDTO().getImageUrl() != null ?
-                        dto.getCastingImageRequestDTO().getImageUrl() : null)
+                .castingImageUrl(imageUrl)
+                .castingImageKeyName(keyName)
                 .build();
     }
 

--- a/src/main/java/cc/backend/amateurShow/converter/AmateurConverter.java
+++ b/src/main/java/cc/backend/amateurShow/converter/AmateurConverter.java
@@ -55,39 +55,60 @@ public class AmateurConverter {
                                                               AmateurShow amateurShow) {
         if (castings == null || castings.isEmpty()) return Collections.emptyList();
 
-        return castings.stream().map(casting -> AmateurCasting.builder()
-                        .amateurShow(amateurShow)
-                        .actorName(casting.getActorName())
-                        .castingName(casting.getCastingName())
-                        .castingImageUrl(casting.getCastingImageRequestDTO().getImageUrl() != null ?
-                                casting.getCastingImageRequestDTO().getImageUrl() : null)
-                        .castingImageKeyName(casting.getCastingImageRequestDTO().getKeyName() != null ?
-                                casting.getCastingImageRequestDTO().getKeyName() : null)
-                        .build())
-                .collect(Collectors.toList());
+        return castings.stream()
+                .map(casting -> {
+                    String imageUrl = null;
+                    String keyName = null;
+
+                    if (casting.getCastingImageRequestDTO() != null) {
+                        imageUrl = casting.getCastingImageRequestDTO().getImageUrl();
+                        keyName = casting.getCastingImageRequestDTO().getKeyName();
+                    }
+
+                    return AmateurCasting.builder()
+                            .amateurShow(amateurShow)
+                            .actorName(casting.getActorName())
+                            .castingName(casting.getCastingName())
+                            .castingImageUrl(imageUrl)
+                            .castingImageKeyName(keyName)
+                            .build();
+                })
+                .toList();
     }
 
     public static AmateurNotice toAmateurNoticeEntity(AmateurEnrollRequestDTO.Notice notice, AmateurShow amateurShow) {
-        if (notice.getContent() == null) return null;
+        if (notice == null || notice.getContent() == null) {
+            return null;
+        }
+
+        String imageUrl = null;
+        if (notice.getNoticeImageRequestDTO() != null) {
+            imageUrl = notice.getNoticeImageRequestDTO().getImageUrl();
+        }
 
         return AmateurNotice.builder()
                 .amateurShow(amateurShow)
                 .content(notice.getContent())
-                .noticeImageUrl(notice.getNoticeImageRequestDTO().getImageUrl() != null ?
-                        notice.getNoticeImageRequestDTO().getImageUrl() : null)
+                .noticeImageUrl(imageUrl)
                 .timeInfo(notice.getTimeInfo())
                 .build();
     }
 
     // 이건 수정용!!
     public static AmateurNotice toAmateurNoticeEntity(AmateurUpdateRequestDTO.UpdateNotice notice, AmateurShow amateurShow) {
-        if (notice.getContent() == null) return null;
+        if (notice == null || notice.getContent() == null) {
+            return null;
+        }
+
+        String imageUrl = null;
+        if (notice.getNoticeImageRequestDTO() != null) {
+            imageUrl = notice.getNoticeImageRequestDTO().getImageUrl();
+        }
 
         return AmateurNotice.builder()
                 .amateurShow(amateurShow)
                 .content(notice.getContent())
-                .noticeImageUrl(notice.getNoticeImageRequestDTO().getImageUrl() != null ?
-                        notice.getNoticeImageRequestDTO().getImageUrl() : null)
+                .noticeImageUrl(imageUrl)
                 .timeInfo(notice.getTimeInfo())
                 .build();
     }

--- a/src/main/java/cc/backend/amateurShow/entity/AmateurCasting.java
+++ b/src/main/java/cc/backend/amateurShow/entity/AmateurCasting.java
@@ -28,7 +28,7 @@ public class AmateurCasting extends BaseEntity {
     private String castingName;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "amateur_show_id")
+    @JoinColumn(name = "amateur_show_id", nullable = false)
     private AmateurShow amateurShow;
 
     public void update(AmateurUpdateRequestDTO.UpdateCasting dto) {

--- a/src/main/java/cc/backend/amateurShow/repository/AmateurShowRepository.java
+++ b/src/main/java/cc/backend/amateurShow/repository/AmateurShowRepository.java
@@ -66,6 +66,16 @@ public interface AmateurShowRepository extends JpaRepository<AmateurShow, Long>,
 
     List<AmateurShow> findByEndGreaterThanEqual(LocalDate today);
 
+    @Query("""
+    SELECT a
+    FROM AmateurShow a
+    WHERE a.end >= :today
+    ORDER BY a.totalSoldTicket DESC, a.start ASC
+""")
+    List<AmateurShow> findHotShows(
+            @Param("today") LocalDate today,
+            Pageable pageable
+    );
 
     @Query("select a from AmateurShow a")
     @EntityGraph(attributePaths = {"amateurRounds", "amateurNotice"}, type = EntityGraph.EntityGraphType.FETCH)

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
@@ -22,7 +22,7 @@ public interface AmateurService {
     List<AmateurShowResponseDTO.AmateurShowList> getShowToday(Long memberId);
     Slice<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Long memberId, Pageable pageable);
     List<AmateurShowResponseDTO.AmateurShowList> getShowRanking(Long memberId);
-    List<AmateurShowResponseDTO.AmateurShowList> getIncomingShow(Long memberId);
+    List<AmateurShowResponseDTO.AmateurShowList> getRecentlyHotShow(Long memberId);
     List<AmateurShowResponseDTO.AmateurShowList> getShowClosing(Long memberId);
 
 

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -24,6 +24,7 @@ import cc.backend.memberLike.entity.MemberLike;
 import cc.backend.memberLike.repository.MemberLikeRepository;
 import cc.backend.ticket.dto.response.ReserveListResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
@@ -422,12 +423,19 @@ public class AmateurServiceImpl implements AmateurService {
         }
 
         //캐스팅 삭제
-        List<AmateurCasting> amateurCastings = amateurShow.getAmateurCastingList();
-        List<Image> castingImages = amateurCastings.stream()
-                .map(casting -> imageRepository.findByFilePathAndContentId(FilePath.casting, casting.getId()))
-                .filter(Objects::nonNull)
+        List<Long> castingIds = amateurShow.getAmateurCastingList()
+                .stream()
+                .map(AmateurCasting::getId)
                 .toList();
-        castingImages.forEach(image -> imageService.deleteImage(image.getId(), memberId));
+
+        if (!castingIds.isEmpty()) {
+            List<Image> castingImages =
+                    imageRepository.findByFilePathAndContentIdIn(
+                            FilePath.casting, castingIds);
+
+            castingImages.forEach(img ->
+                    imageService.deleteImage(img.getId(), memberId));
+        }
 
         //amateurShow 삭제
         amateurShowRepository.delete(amateurShow);
@@ -621,32 +629,29 @@ public class AmateurServiceImpl implements AmateurService {
     }
 
     @Override
-    public List<AmateurShowResponseDTO.AmateurShowList> getIncomingShow (Long memberId){
+    public List<AmateurShowResponseDTO.AmateurShowList> getRecentlyHotShow (Long memberId){
         memberRepository.findById(memberId).orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
 
-        Collator collator = Collator.getInstance(Locale.KOREAN); //한글 사전식 정렬
 
-        // 종료일이 오늘 이후인 공연만 DB에서 조회
+        // 종료되지 않은 공연 중, 판매량 기준 상위 3개
         LocalDate today = LocalDate.now();
-        List<AmateurShow> shows = amateurShowRepository.findByEndGreaterThanEqual(today);
+        List<AmateurShow> shows = amateurShowRepository.findHotShows(today, PageRequest.of(0, 3));
 
         return shows.stream()
-                // 시작일 기준 오름차순 → 이름 기준 오름차순(한글 사전식)
-                .sorted(Comparator
-                        .comparing(AmateurShow::getStart)
-                        .thenComparing(AmateurShow::getName, Comparator.nullsLast(collator)))
-                .limit(3)
-                .map(show -> {
-                    String schedule = AmateurConverter.mergeSchedule(show.getStart(), show.getEnd());
-                    return AmateurShowResponseDTO.AmateurShowList.builder()
-                            .amateurShowId(show.getId())
-                            .name(show.getName())
-                            .detailAddress(show.getDetailAddress())
-                            .schedule(schedule)
-                            .posterImageUrl(show.getPosterImageUrl())
-                            .build();
-                })
-                .collect(Collectors.toList());
+                .map(show -> AmateurShowResponseDTO.AmateurShowList.builder()
+                        .amateurShowId(show.getId())
+                        .name(show.getName())
+                        .detailAddress(show.getDetailAddress())
+                        .schedule(
+                                AmateurConverter.mergeSchedule(
+                                        show.getStart(),
+                                        show.getEnd()
+                                )
+                        )
+                        .posterImageUrl(show.getPosterImageUrl())
+                        .build()
+                )
+                .toList();
 
     }
 

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -635,7 +635,7 @@ public class AmateurServiceImpl implements AmateurService {
                 .sorted(Comparator
                         .comparing(AmateurShow::getStart)
                         .thenComparing(AmateurShow::getName, Comparator.nullsLast(collator)))
-                .limit(10)
+                .limit(3)
                 .map(show -> {
                     String schedule = AmateurConverter.mergeSchedule(show.getStart(), show.getEnd());
                     return AmateurShowResponseDTO.AmateurShowList.builder()

--- a/src/main/java/cc/backend/image/repository/ImageRepository.java
+++ b/src/main/java/cc/backend/image/repository/ImageRepository.java
@@ -24,4 +24,9 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     <Optional> Image findByKeyName(String keyName);
 
     <Optional> Image findByFilePathAndKeyName(FilePath filePath, String keyName);
+
+    List<Image> findByFilePathAndContentIdIn(
+            FilePath filePath,
+            List<Long> contentIds
+    );
 }

--- a/src/main/java/cc/backend/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/cc/backend/notice/service/NoticeServiceImpl.java
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/cc/backend/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/cc/backend/notice/service/NoticeServiceImpl.java
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -101,7 +102,7 @@ public class NoticeServiceImpl implements NoticeService {
 
         memberNoticeRepository.save(MemberNotice.builder()
                                  .notice(newNotice)
-                                 .member(commentWriter).build());
+                                 .member(boardWriter).build());
 
         return NoticeResponseDTO.NoticeDTO.builder()
                 .id(newNotice.getId())


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - deleteShow 관련 이미지 id로 뽑아서 한번에 삭제하도록 -> 성능 개선
    - 댓글작성자가 아닌 게시글 작성자에게 알림가도록 수정
    - 핫한 공연 totalSoldTicket 순서로 3개 뽑아오기
    - 컨버터에서 npe 처리
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incoming shows endpoint now returns a "recently hot" list limited to the top 3 trending shows.

* **Bug Fixes**
  * Comment notifications now route to the board author instead of the commenter.
  * Image cleanup during show deletion now removes related files in batch.
  * Safer handling of optional images to prevent null-related errors.

* **Database**
  * Casting entries now require a non-null parent show reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->