### PR TITLE
[FEAT] 사진첩과 연결할 공연 조회 api 개발, 일반유저 접근 페이지 수정, specification 이용한 approval 조건 추가

### DIFF
--- a/src/main/java/cc/backend/amateurShow/controller/AmateurController.java
+++ b/src/main/java/cc/backend/amateurShow/controller/AmateurController.java
@@ -30,7 +30,6 @@ import java.util.List;
 @RequestMapping("/amateurs")
 public class AmateurController {
 
-    private final MemberService memberService;
     private final AmateurService amateurService;
 
     @PreAuthorize("hasRole('PERFORMER')")
@@ -57,50 +56,46 @@ public class AmateurController {
 
     @GetMapping("/{amateurShowId}")
     @Operation(summary = "소극장 공연 조회 - 단건")
-    public ApiResponse<AmateurShowResponseDTO.AmateurShowResult> getAmateurShow(@AuthenticationPrincipal(expression = "member") Member member,
-                                                                                @PathVariable Long amateurShowId){
-        return ApiResponse.onSuccess(amateurService.getAmateurShow(member.getId(), amateurShowId));
+    public ApiResponse<AmateurShowResponseDTO.AmateurShowResult> getAmateurShow(@PathVariable Long amateurShowId){
+        return ApiResponse.onSuccess(amateurService.getAmateurShow(amateurShowId));
     }
 
     @GetMapping("/ranking")
     @Operation(summary = "소극장 공연 랭킹 조회 API")
-    public ApiResponse<List<AmateurShowResponseDTO.AmateurShowList>> getShowRanking(@AuthenticationPrincipal(expression = "member") Member member) {
-        return ApiResponse.onSuccess(amateurService.getShowRanking(member.getId()));
+    public ApiResponse<List<AmateurShowResponseDTO.AmateurShowList>> getShowRanking() {
+        return ApiResponse.onSuccess(amateurService.getShowRanking());
     }
 
     @GetMapping("/today")
     @Operation(summary = "오늘 진행하는 소극장 공연 조회 API")
-    public ApiResponse<SliceResponse<AmateurShowResponseDTO.AmateurShowList>> getShowToday(
-            @AuthenticationPrincipal(expression = "member") Member member, @ParameterObject Pageable pageable) {
-        return ApiResponse.onSuccess(SliceResponse.of(amateurService.getShowToday(member.getId(), pageable)));
+    public ApiResponse<SliceResponse<AmateurShowResponseDTO.AmateurShowList>> getShowToday( @ParameterObject Pageable pageable) {
+        return ApiResponse.onSuccess(SliceResponse.of(amateurService.getShowToday(pageable)));
     }
 
     @GetMapping("/ongoing")
     @Operation(summary = "현재 진행중인 소극장 공연 조회 API")
-    public ApiResponse<SliceResponse<AmateurShowList>> getShowOngoing(
-        @AuthenticationPrincipal(expression = "member") Member member, @ParameterObject Pageable pageable
+    public ApiResponse<SliceResponse<AmateurShowList>> getShowOngoing( @ParameterObject Pageable pageable
     ) {
-        Slice<AmateurShowList> sliceResult = amateurService.getShowOngoing(member.getId(), pageable);
+        Slice<AmateurShowList> sliceResult = amateurService.getShowOngoing(pageable);
         return ApiResponse.onSuccess(SliceResponse.of(sliceResult));
     }
 
     @GetMapping("/closing")
     @Operation(summary = "오늘 마감인 공연 조회 API")
-    public ApiResponse<List<AmateurShowResponseDTO.AmateurShowList>> getShowClosing(@AuthenticationPrincipal(expression = "member") Member member) {
-        return ApiResponse.onSuccess(amateurService.getShowClosing(member.getId()));
+    public ApiResponse<List<AmateurShowResponseDTO.AmateurShowList>> getShowClosing() {
+        return ApiResponse.onSuccess(amateurService.getShowClosing());
     }
 
     @GetMapping("/recentlyHot")
     @Operation(summary = "요즘 핫한 소극장 연극 조회 API")
-    public ApiResponse<List<AmateurShowResponseDTO.AmateurShowList>> getRecentlyHotShow(@AuthenticationPrincipal(expression = "member") Member member) {
-        return ApiResponse.onSuccess(amateurService.getRecentlyHotShow(member.getId()));
+    public ApiResponse<List<AmateurShowResponseDTO.AmateurShowList>> getRecentlyHotShow() {
+        return ApiResponse.onSuccess(amateurService.getRecentlyHotShow());
         }
 
     @GetMapping("/incoming")
     @Operation(summary = "임박한 공연 조회 API")
-    public ApiResponse<SliceResponse<AmateurShowResponseDTO.AmateurShowList>> getShowIncoming(
-            @AuthenticationPrincipal(expression = "member") Member member, @ParameterObject Pageable pageable) {
-        Slice<AmateurShowList> sliceResult = amateurService.getShowToday(member.getId(), pageable);
+    public ApiResponse<SliceResponse<AmateurShowResponseDTO.AmateurShowList>> getShowIncoming(@ParameterObject Pageable pageable) {
+        Slice<AmateurShowList> sliceResult = amateurService.getShowToday(pageable);
         return ApiResponse.onSuccess(SliceResponse.of(sliceResult));
     }
 }

--- a/src/main/java/cc/backend/amateurShow/repository/AmateurShowRepository.java
+++ b/src/main/java/cc/backend/amateurShow/repository/AmateurShowRepository.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 @Repository
 public interface AmateurShowRepository extends JpaRepository<AmateurShow, Long>, JpaSpecificationExecutor<AmateurShow> {
-    List<AmateurShow> findAllByMemberId(Long memberId);
 
     @Query("SELECT a FROM AmateurShow a WHERE a.id = :id")
     Optional<AmateurShow> findByIdWithDetails(@Param("id") Long id);
@@ -33,9 +32,6 @@ public interface AmateurShowRepository extends JpaRepository<AmateurShow, Long>,
     Slice<AmateurShow> findAllByMemberIdAndStatusOrderByIdDesc(@Param("memberId") Long memberId,
                                                                @Param("status") AmateurShowStatus status,
                                                                Pageable pageable);
-
-    List<AmateurShow> findAllByMemberIdOrderByUpdatedAtDesc(@Param("memberId") Long memberId);
-
 
     @Query("""
        select s
@@ -60,16 +56,15 @@ public interface AmateurShowRepository extends JpaRepository<AmateurShow, Long>,
 
     long countByMember_Id(Long memberId);
 
-
     Page<AmateurShow> findByNameContainingIgnoreCase(String showName, Pageable pageable);
 
-
-    List<AmateurShow> findByEndGreaterThanEqual(LocalDate today);
+    List<AmateurShow> findAllByMemberId(Long memberId);
 
     @Query("""
     SELECT s
     FROM AmateurShow s
     WHERE s.end >= :today
+    AND s.approvalStatus = 'APPROVED'
     ORDER BY s.end ASC
 """)
     List<AmateurShow> findHotShows(

--- a/src/main/java/cc/backend/amateurShow/repository/specification/AmateurShowSpecification.java
+++ b/src/main/java/cc/backend/amateurShow/repository/specification/AmateurShowSpecification.java
@@ -1,8 +1,10 @@
 package cc.backend.amateurShow.repository.specification;
 
+import cc.backend.amateurShow.entity.AmateurRounds;
 import cc.backend.amateurShow.entity.AmateurShow;
 import cc.backend.amateurShow.entity.enums.ApprovalStatus;
 import cc.backend.member.entity.Member;
+import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Path;
 import org.springframework.data.jpa.domain.Specification;
@@ -65,23 +67,30 @@ public class AmateurShowSpecification {
      */
     public static Specification<AmateurShow> hasLastRoundOn(LocalDate today) {
         return (root, query, cb) -> {
-            query.distinct(true); // JOIN으로 중복 제거
+            query.distinct(true);
 
-            // 서브쿼리: 각 공연의 마지막 회차 날짜
+            // 서브쿼리: AmateurRounds 기준
             var subquery = query.subquery(LocalDate.class);
-            var subRoot = subquery.from(root.getJavaType()); // AmateurShow
+            var roundRoot = subquery.from(AmateurRounds.class);
 
-            // Join으로 회차 가져오기
-            Join<Object, Object> rounds = subRoot.join("amateurRounds");
+            // MAX(DATE(performanceDateTime))
+            Expression<LocalDate> lastRoundDate =
+                    cb.greatest(
+                            cb.function(
+                                    "DATE",
+                                    LocalDate.class,
+                                    roundRoot.get("performanceDateTime")
+                            )
+                    );
 
-            // 마지막 회차 날짜
-            Path<LocalDate> perfDate = (Path<LocalDate>) rounds.get("performanceDateTime").as(LocalDate.class);
-            subquery.select(cb.greatest(perfDate));
+            subquery.select(lastRoundDate);
 
-            // 서브쿼리 조건: 해당 공연
-            subquery.where(cb.equal(subRoot, root));
+            // 해당 공연의 회차만 대상
+            subquery.where(
+                    cb.equal(roundRoot.get("amateurShow"), root)
+            );
 
-            // 오늘과 비교
+            // 마지막 회차 날짜 == today
             return cb.equal(subquery, today);
         };
     }

--- a/src/main/java/cc/backend/amateurShow/repository/specification/AmateurShowSpecification.java
+++ b/src/main/java/cc/backend/amateurShow/repository/specification/AmateurShowSpecification.java
@@ -3,16 +3,13 @@ package cc.backend.amateurShow.repository.specification;
 import cc.backend.amateurShow.entity.AmateurShow;
 import cc.backend.amateurShow.entity.enums.ApprovalStatus;
 import cc.backend.member.entity.Member;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Path;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;
 
 public class AmateurShowSpecification {
-
-    public static Specification<AmateurShow> isAudienceVisible() {
-        return (root, query, criteriaBuilder) ->
-                criteriaBuilder.equal(root.get("approvalStatus"), ApprovalStatus.APPROVED);
-    }
 
     public static Specification<AmateurShow> isWrittenBy(Member performer) {
         return (root, query, criteriaBuilder) ->
@@ -44,5 +41,48 @@ public class AmateurShowSpecification {
     public static Specification<AmateurShow> isNotEnded(LocalDate today) {
         return (root, query, criteriaBuilder) ->
                 criteriaBuilder.greaterThanOrEqualTo(root.get("end"), today);
+    }
+
+    /**
+     * 오늘 날짜 회차 필터
+     * performanceDateTime이 전달된 날짜(date)와 일치하는 공연만
+     */
+    public static Specification<AmateurShow> hasRoundOn(LocalDate date) {
+        return (root, query, cb) -> {
+            // 중복 제거 필요 시
+            query.distinct(true);
+
+            // Join to amateurRounds
+            var rounds = root.join("amateurRounds");
+
+            // 날짜만 비교 (MySQL 기준)
+            return cb.equal(cb.function("DATE", LocalDate.class, rounds.get("performanceDateTime")), date);
+        };
+    }
+
+    /**
+     * 마지막 회차 날짜가 오늘인 공연 필터
+     */
+    public static Specification<AmateurShow> hasLastRoundOn(LocalDate today) {
+        return (root, query, cb) -> {
+            query.distinct(true); // JOIN으로 중복 제거
+
+            // 서브쿼리: 각 공연의 마지막 회차 날짜
+            var subquery = query.subquery(LocalDate.class);
+            var subRoot = subquery.from(root.getJavaType()); // AmateurShow
+
+            // Join으로 회차 가져오기
+            Join<Object, Object> rounds = subRoot.join("amateurRounds");
+
+            // 마지막 회차 날짜
+            Path<LocalDate> perfDate = (Path<LocalDate>) rounds.get("performanceDateTime").as(LocalDate.class);
+            subquery.select(cb.greatest(perfDate));
+
+            // 서브쿼리 조건: 해당 공연
+            subquery.where(cb.equal(subRoot, root));
+
+            // 오늘과 비교
+            return cb.equal(subquery, today);
+        };
     }
 }

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
@@ -5,7 +5,6 @@ import cc.backend.amateurShow.dto.AmateurEnrollResponseDTO;
 import cc.backend.amateurShow.dto.AmateurShowResponseDTO;
 import cc.backend.amateurShow.dto.AmateurUpdateRequestDTO;
 import cc.backend.amateurShow.entity.AmateurShowStatus;
-import cc.backend.ticket.dto.response.ReserveListResponseDTO;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -16,14 +15,14 @@ import java.util.List;
 public interface AmateurService {
     AmateurEnrollResponseDTO.AmateurEnrollResult enrollShow(Long memberId,
                                                                    AmateurEnrollRequestDTO requestDTO);
-    AmateurShowResponseDTO.AmateurShowResult getAmateurShow(Long memberId, Long amateurId);
+    AmateurShowResponseDTO.AmateurShowResult getAmateurShow(Long amateurId);
     AmateurEnrollResponseDTO.AmateurEnrollResult updateShow(Long memberId, Long showId, AmateurUpdateRequestDTO requestDTO);
     void deleteShow(Long memberId, Long amateurShowId);
-    Slice<AmateurShowResponseDTO.AmateurShowList> getShowToday(Long memberId, Pageable pageable);
-    Slice<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Long memberId, Pageable pageable);
-    List<AmateurShowResponseDTO.AmateurShowList> getShowRanking(Long memberId);
-    List<AmateurShowResponseDTO.AmateurShowList> getRecentlyHotShow(Long memberId);
-    List<AmateurShowResponseDTO.AmateurShowList> getShowClosing(Long memberId);
+    Slice<AmateurShowResponseDTO.AmateurShowList> getShowToday(Pageable pageable);
+    Slice<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Pageable pageable);
+    List<AmateurShowResponseDTO.AmateurShowList> getShowRanking();
+    List<AmateurShowResponseDTO.AmateurShowList> getRecentlyHotShow();
+    List<AmateurShowResponseDTO.AmateurShowList> getShowClosing();
 
 
     Slice<AmateurShowResponseDTO.MyShowAmateurShowList> getMyAmateurShow(Long memberId, AmateurShowStatus showStatus, Pageable pageable);

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -558,14 +558,7 @@ public class AmateurServiceImpl implements AmateurService {
                 .where(AmateurShowSpecification.isApproved())
                 .and(AmateurShowSpecification.hasLastRoundOn(today));
 
-        // Pageable로 start 기준 오름차순 정렬, limit 없이 전체 조회
-        Pageable sortedPage = PageRequest.of(
-                0,
-                Integer.MAX_VALUE,
-                Sort.by("start").ascending());
-
-        List<AmateurShow> shows = amateurShowRepository.findAll(spec, sortedPage).getContent();
-
+        List<AmateurShow> shows = amateurShowRepository.findAll(spec, Sort.by("start").ascending());
         // DTO 변환
         return shows.stream()
                 .map(show -> {

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -3,10 +3,12 @@ package cc.backend.amateurShow.service.amateurShowService;
 import cc.backend.amateurShow.dto.AmateurShowResponseDTO;
 import cc.backend.amateurShow.dto.AmateurUpdateRequestDTO;
 import cc.backend.amateurShow.entity.*;
+import cc.backend.amateurShow.entity.enums.ApprovalStatus;
 import cc.backend.amateurShow.repository.*;
 import cc.backend.amateurShow.converter.AmateurConverter;
 import cc.backend.amateurShow.dto.AmateurEnrollRequestDTO;
 import cc.backend.amateurShow.dto.AmateurEnrollResponseDTO;
+import cc.backend.amateurShow.repository.specification.AmateurShowSpecification;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import cc.backend.apiPayLoad.exception.GeneralException;
 import cc.backend.board.entity.enums.BoardType;
@@ -24,11 +26,9 @@ import cc.backend.memberLike.entity.MemberLike;
 import cc.backend.memberLike.repository.MemberLikeRepository;
 import cc.backend.ticket.dto.response.ReserveListResponseDTO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -443,134 +443,96 @@ public class AmateurServiceImpl implements AmateurService {
 
     // 소극장 공연 단건 조회
     @Override
-    public AmateurShowResponseDTO.AmateurShowResult getAmateurShow(Long memberId, Long amateurShowId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
-
+    public AmateurShowResponseDTO.AmateurShowResult getAmateurShow(Long amateurShowId) {
         AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
-
 
         return AmateurConverter.toResponseDTO(amateurShow);
     }
 
     // 오늘 진행하는 소극장 공연 리스트 조회
     @Override
-    public Slice<AmateurShowResponseDTO.AmateurShowList> getShowToday(Long memberId, Pageable pageable) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
+    public Slice<AmateurShowResponseDTO.AmateurShowList> getShowToday(Pageable pageable) {
 
         LocalDate today = LocalDate.now();
-        List<AmateurShow> allShows = amateurShowRepository.findAllWithRounds();
 
-        // 오늘 날짜를 가진 회차가 있는 공연만
-        List<AmateurShowResponseDTO.AmateurShowList> result = allShows.stream()
-                .filter(show -> show.getAmateurRounds().stream()
-                        .anyMatch(round ->
-                                round.getPerformanceDateTime()
-                                        .toLocalDate()
-                                        .equals(today)
-                        )
-                )
-                .distinct()
-                .sorted(Comparator.comparing(AmateurShow::getStart)) // 정렬 필요하면 유지
-                .map(show -> {
-                    String schedule = AmateurConverter.mergeSchedule(
-                            show.getStart(),
-                            show.getEnd()
-                    );
-                    return AmateurShowResponseDTO.AmateurShowList.builder()
-                            .amateurShowId(show.getId())
-                            .name(show.getName())
-                            .detailAddress(show.getDetailAddress())
-                            .schedule(schedule)
-                            .posterImageUrl(show.getPosterImageUrl())
-                            .build();
-                })
-                .collect(Collectors.toList());
+        // Specification 조합 : 승인된 공연 + 오늘 공연하는 회차 존재
+        Specification<AmateurShow> spec = Specification
+                .where(AmateurShowSpecification.isApproved())
+                .and(AmateurShowSpecification.hasRoundOn(today));
 
-        // ===== Slice 페이징 처리 =====
-        int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), result.size());
+        // DB 레벨에서 페이징 + 필터링
+        Slice<AmateurShow> showSlice = amateurShowRepository.findAll(spec, pageable);
 
-        List<AmateurShowResponseDTO.AmateurShowList> content = new ArrayList<>();
-        if (start < result.size()) {
-            content = result.subList(start, end);
-        }
-
-        boolean hasNext = end < result.size();
-
-        return new SliceImpl<>(content, pageable, hasNext);
+        // DTO 변환
+        return showSlice.map(show -> {
+            String schedule = AmateurConverter.mergeSchedule(show.getStart(), show.getEnd());
+            return AmateurShowResponseDTO.AmateurShowList.builder()
+                    .amateurShowId(show.getId())
+                    .name(show.getName())
+                    .detailAddress(show.getDetailAddress())
+                    .schedule(schedule)
+                    .posterImageUrl(show.getPosterImageUrl())
+                    .build();
+        });
     }
 
     // 현재 진행중인 소극장 공연 리스트 조회
     @Override
-    public Slice<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Long memberId, Pageable pageable) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
+    public Slice<AmateurShowResponseDTO.AmateurShowList> getShowOngoing(Pageable pageable) {
 
         LocalDate today = LocalDate.now();
-        List<AmateurShow> allShows = amateurShowRepository.findAllWithRounds();
 
-        List<AmateurShowResponseDTO.AmateurShowList> result = allShows.stream()
-                // 오늘 날짜가 schedule 기간 내에 포함된 공연만 필터링
-                .filter(show -> {
-                    LocalDate start = show.getStart();
-                    LocalDate end = show.getEnd();
-                    return start != null && end != null
-                            && !today.isBefore(start)
-                            && !today.isAfter(end);
-                })
-                // 공연 시작일 기준 오름차순 정렬
-                .sorted(Comparator.comparing(AmateurShow::getStart))
-                // DTO로 변환
-                .map(show -> {
-                    String schedule = AmateurConverter.mergeSchedule(show.getStart(), show.getEnd());
-                    return AmateurShowResponseDTO.AmateurShowList.builder()
-                            .amateurShowId(show.getId())
-                            .name(show.getName())
-                            .detailAddress(show.getDetailAddress())
-                            .schedule(schedule)
-                            .posterImageUrl(show.getPosterImageUrl())
-                            .build();
-                })
-                .collect(Collectors.toList());
+        // Specification 조합: 승인 + 현재 진행 중인 공연
+        Specification<AmateurShow> spec = Specification
+                .where(AmateurShowSpecification.isApproved())
+                .and(AmateurShowSpecification.isOngoing(today));
 
-        int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), result.size());
+        Pageable sortedPage = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by("start").ascending()
+        );
 
-        List<AmateurShowResponseDTO.AmateurShowList> content = new ArrayList<>();
-        if (start < result.size()) {
-            content = result.subList(start, end);
-        }
+        Slice<AmateurShow> showSlice = amateurShowRepository.findAll(spec, sortedPage);
 
-        boolean hasNext = end < result.size();
-
-        return new SliceImpl<>(content, pageable, hasNext); // 시그니처 (List<DTO>, pageable, hasNext)
+        return showSlice.map(show -> {
+            String schedule = AmateurConverter.mergeSchedule(show.getStart(), show.getEnd());
+            return AmateurShowResponseDTO.AmateurShowList.builder()
+                    .amateurShowId(show.getId())
+                    .name(show.getName())
+                    .detailAddress(show.getDetailAddress())
+                    .schedule(schedule)
+                    .posterImageUrl(show.getPosterImageUrl())
+                    .build();
+        });
     }
 
     // 소극장 공연 랭킹 리스트 조회
     @Override
-    public List<AmateurShowResponseDTO.AmateurShowList> getShowRanking(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
+    public List<AmateurShowResponseDTO.AmateurShowList> getShowRanking() {
 
         LocalDate today = LocalDate.now();
-        List<AmateurShow> shows = amateurShowRepository.findAllWithRounds();
 
-        return shows.stream()
-                // 종료일이 오늘 이후인 공연만 필터링
-                .filter(show -> {
-                    LocalDate start = show.getStart();
-                    LocalDate end = show.getEnd();
-                    return start != null && end != null && !today.isAfter(end);
-                })
-                // 정렬: 판매 티켓 수 내림차순 → 시작일 오름차순
-                .sorted(Comparator
-                        .comparing(AmateurShow::getTotalSoldTicket, Comparator.nullsLast(Comparator.reverseOrder()))
-                        .thenComparing(AmateurShow::getStart))
-                .limit(10)
-                // DTO 변환
+        // Specification 조합: 종료일이 오늘 이후 + 승인된 공연
+        Specification<AmateurShow> spec = Specification
+                .where(AmateurShowSpecification.isNotEnded(today))
+                .and(AmateurShowSpecification.isApproved());
+
+        // Pageable로 정렬 + limit 10 적용
+        Pageable sortedPage = PageRequest.of(
+                0,
+                10,
+                Sort.by(
+                        Sort.Order.desc("totalSoldTicket"),  // 판매 티켓 수 내림차순
+                        Sort.Order.asc("start")             // 시작일 오름차순
+                )
+        );
+
+        Slice<AmateurShow> showSlice = amateurShowRepository.findAll(spec, sortedPage);
+
+        // DTO 변환
+        return showSlice.stream()
                 .map(show -> {
                     String schedule = AmateurConverter.mergeSchedule(show.getStart(), show.getEnd());
                     return AmateurShowResponseDTO.AmateurShowList.builder()
@@ -582,40 +544,41 @@ public class AmateurServiceImpl implements AmateurService {
                             .build();
                 })
                 .collect(Collectors.toList());
+
     }
 
     // 오늘 마감인 소극장 공연 리스트 조회
     @Override
-    public List<AmateurShowResponseDTO.AmateurShowList> getShowClosing(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
+    public List<AmateurShowResponseDTO.AmateurShowList> getShowClosing() {
 
-        List<AmateurShow> allShows = amateurShowRepository.findAllWithRounds();
         LocalDate today = LocalDate.now();
 
-        List<AmateurShowResponseDTO.AmateurShowList> result = new ArrayList<>();
+        // Specification 조합: 승인된 공연 + 마지막 회차가 오늘인 공연
+        Specification<AmateurShow> spec = Specification
+                .where(AmateurShowSpecification.isApproved())
+                .and(AmateurShowSpecification.hasLastRoundOn(today));
 
-        for (AmateurShow show : allShows) {
-            // 각 공연의 회차들 중 젤 마지막 회차 날짜 구하기
-            Optional<LocalDate> lastDate = show.getAmateurRounds().stream()
-                    .map(r -> r.getPerformanceDateTime().toLocalDate()) // 회차 날짜만 추출
-                    .max(Comparator.naturalOrder()); // 젤 늦은 날짜 추출
+        // Pageable로 start 기준 오름차순 정렬, limit 없이 전체 조회
+        Pageable sortedPage = PageRequest.of(
+                0,
+                Integer.MAX_VALUE,
+                Sort.by("start").ascending());
 
-            if (lastDate.isPresent() && lastDate.get().isEqual(today)) { // 마지막 회차 날짜가 오늘인 경우
-                String schedule = AmateurConverter.mergeSchedule(show.getStart(), show.getEnd());
+        List<AmateurShow> shows = amateurShowRepository.findAll(spec, sortedPage).getContent();
 
-                result.add(AmateurShowResponseDTO.AmateurShowList.builder()
-                        .amateurShowId(show.getId())
-                        .name(show.getName())
-                        //.place(show.getPlace())
-                        .detailAddress(show.getDetailAddress())
-                        .schedule(schedule)
-                        .posterImageUrl(show.getPosterImageUrl())
-                        .build());
-            }
-        }
-
-        return result;
+        // DTO 변환
+        return shows.stream()
+                .map(show -> {
+                    String schedule = AmateurConverter.mergeSchedule(show.getStart(), show.getEnd());
+                    return AmateurShowResponseDTO.AmateurShowList.builder()
+                            .amateurShowId(show.getId())
+                            .name(show.getName())
+                            .detailAddress(show.getDetailAddress())
+                            .schedule(schedule)
+                            .posterImageUrl(show.getPosterImageUrl())
+                            .build();
+                })
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -651,11 +614,9 @@ public class AmateurServiceImpl implements AmateurService {
     }
 
     @Override
-    public List<AmateurShowResponseDTO.AmateurShowList> getRecentlyHotShow (Long memberId){
-        memberRepository.findById(memberId).orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
+    public List<AmateurShowResponseDTO.AmateurShowList> getRecentlyHotShow (){
 
-
-        // 종료되지 않은 공연 중, 마감이 얼마 안남은 3개
+        // 종료되지 않은 공연 중, 마감이 얼마 안남은 3개 - specification 없이 바로
         LocalDate today = LocalDate.now();
         List<AmateurShow> shows = amateurShowRepository.findHotShows(today, PageRequest.of(0, 3));
 

--- a/src/main/java/cc/backend/photoAlbum/controller/PhotoAlbumController.java
+++ b/src/main/java/cc/backend/photoAlbum/controller/PhotoAlbumController.java
@@ -29,6 +29,15 @@ import java.util.List;
 public class PhotoAlbumController {
     private final PhotoAlbumService photoAlbumService;
 
+    @PreAuthorize("hasRole('PERFORMER')")
+    @GetMapping("/getMyShows")
+    @Operation(summary = "사진첩 등록/수정 시 연결할 내 공연 조회 API", description = "내가 등록한 공연 조회 API")
+    public ApiResponse<List<PhotoAlbumResponseDTO.MyShowsForPhotoAlbumDTO>> getMyShows(
+            @AuthenticationPrincipal(expression = "member") Member member) {
+        return ApiResponse.onSuccess(photoAlbumService.getMyShows(member.getId()));
+    }
+
+
     @GetMapping("/{photoAlbumId}")
     @Operation(summary = "사진첩 단건 조회 API", description = "공연별 사진첩을 단건 조회하는 API 입니다.")
     public ApiResponse<PhotoAlbumResponseDTO.PhotoAlbumResultWithPresignedUrlDTO> getPhotoAlbum(
@@ -66,6 +75,7 @@ public class PhotoAlbumController {
         return ApiResponse.onSuccess(photoAlbumService.updatePhotoAlbum(photoAlbumId,requestDTO, member.getId()));
     }
 
+    @PreAuthorize("hasRole('PERFORMER')")
     @DeleteMapping("/{photoAlbumId}")
     @Operation(summary = "사진첩 삭제 API", description = "공연별 사진첩을 삭제하는 API 입니다.")
     public ApiResponse<String> deletePhotoAlbum(
@@ -77,10 +87,9 @@ public class PhotoAlbumController {
     @GetMapping("")
     @Operation(summary = "메뉴에서 전체 사진첩 조회 API", description = "최근 올라온 사진첩을 전체 조회하는 API 입니다.")
     public ApiResponse<PhotoAlbumResponseDTO.ScrollMemberPhotoAlbumDTO> getAllPhotoAlbum(
-            @AuthenticationPrincipal(expression = "member") Member member,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "20") int size) {
-        return ApiResponse.onSuccess(photoAlbumService.getAllRecentPhotoAlbumList(member.getId(), cursorId, size));
+        return ApiResponse.onSuccess(photoAlbumService.getAllRecentPhotoAlbumList(cursorId, size));
     }
 
     @GetMapping("/member/{memberId}/shows")

--- a/src/main/java/cc/backend/photoAlbum/dto/PhotoAlbumResponseDTO.java
+++ b/src/main/java/cc/backend/photoAlbum/dto/PhotoAlbumResponseDTO.java
@@ -73,6 +73,15 @@ public class PhotoAlbumResponseDTO {
         private Long nextCursor;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyShowsForPhotoAlbumDTO {
+        private Long memberId;
+        private Long amateurShowId;
+        private String schedule;
+    }
 
 
 }

--- a/src/main/java/cc/backend/photoAlbum/service/PhotoAlbumService.java
+++ b/src/main/java/cc/backend/photoAlbum/service/PhotoAlbumService.java
@@ -17,6 +17,7 @@ public interface PhotoAlbumService {
     public Slice<PhotoAlbumResponseDTO.SinglePhotoAlbumDTO> getPhotoAlbumList(Long memberId, Long performerId, Pageable pageable);
     public PhotoAlbumResponseDTO.PhotoAlbumResultDTO updatePhotoAlbum(Long photoAlbumId, PhotoAlbumRequestDTO.CreatePhotoAlbumDTO requestDTO, Long memberId);
     public String deletePhotoAlbum(Long photoAlbumId, Long memberId);
-    public PhotoAlbumResponseDTO.ScrollMemberPhotoAlbumDTO getAllRecentPhotoAlbumList(Long memberId, Long cursorId, int size);
+    public PhotoAlbumResponseDTO.ScrollMemberPhotoAlbumDTO getAllRecentPhotoAlbumList(Long cursorId, int size);
     public PerformerShowListResponseDTO getPerformerShows(Long memberId, Pageable pageable);
+    public List<PhotoAlbumResponseDTO.MyShowsForPhotoAlbumDTO> getMyShows(Long memberId);
 }

--- a/src/main/java/cc/backend/photoAlbum/service/PhotoAlbumServiceImpl.java
+++ b/src/main/java/cc/backend/photoAlbum/service/PhotoAlbumServiceImpl.java
@@ -12,6 +12,7 @@ import cc.backend.image.entity.Image;
 import cc.backend.image.repository.ImageRepository;
 import cc.backend.image.service.ImageService;
 import cc.backend.member.entity.Member;
+import cc.backend.member.enumerate.Role;
 import cc.backend.member.repository.MemberRepository;
 import cc.backend.photoAlbum.dto.PerformerShowListResponseDTO;
 import cc.backend.photoAlbum.dto.PhotoAlbumRequestDTO;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -42,7 +44,6 @@ public class PhotoAlbumServiceImpl implements PhotoAlbumService {
     private final ImageRepository imageRepository;
     private final ImageService imageService;
     private final MemberRepository memberRepository;
-    private final S3Service s3Service;
 
     @Override
     @Transactional
@@ -264,12 +265,9 @@ public class PhotoAlbumServiceImpl implements PhotoAlbumService {
     }
 
     @Override
-    public PhotoAlbumResponseDTO.ScrollMemberPhotoAlbumDTO getAllRecentPhotoAlbumList(Long memberId, Long cursorId, int size){
+    public PhotoAlbumResponseDTO.ScrollMemberPhotoAlbumDTO getAllRecentPhotoAlbumList(Long cursorId, int size){
 
-        //로그인 검사
-        memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED));
-
+        //로그인 검사 X -> 방문자 첫화면 허용
 
         // 다음 사진첩 조회 (cursor 기반, size + 1로 hasNext 판단)
         Pageable pageable = PageRequest.of(0, size + 1);
@@ -367,4 +365,46 @@ public class PhotoAlbumServiceImpl implements PhotoAlbumService {
         return result;
     }
 
+    @Override
+    public List<PhotoAlbumResponseDTO.MyShowsForPhotoAlbumDTO> getMyShows(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if(member.getRole() != Role.PERFORMER){
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED);
+        }
+
+        List<AmateurShow> amateurShows = amateurShowRepository.findAllByMemberId(memberId);
+
+        return amateurShows.stream()
+                .map(show->{
+                    String schedule = mergeScheduleWithoutDays(show.getStart(), show.getEnd());
+                    return PhotoAlbumResponseDTO.MyShowsForPhotoAlbumDTO.builder()
+                            .amateurShowId(show.getId())
+                            .memberId(memberId)
+                            .schedule(schedule)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private static String mergeScheduleWithoutDays(LocalDate start, LocalDate end) {
+        try {
+            if (start == null || end == null) {
+                return "";
+            }
+
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+            String startStr = start.format(formatter);
+            String endStr   = end.format(formatter);
+
+            // 최종 결과: "2025.10.02~2025.10.05"
+            return startStr + "~" + endStr;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
 }


### PR DESCRIPTION

1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - 사진첩과 연결할 공연 조회 api 개발
    - 일반유저 접근 페이지 수정
    - specification 이용한 approval 조건 추가
    - 공연 조회 api 쿼리 성능 최적화
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "My Shows" endpoint for performers to list their shows for photo albums.

* **Improvements**
  * Several show listing endpoints (ranking, today, ongoing, closing, recently hot, incoming) are now public — no login required.
  * Photo album browsing is now public (visitor-first cursor paging).
  * Show filtering improved to enforce approval status and support date-based round filtering.

* **Security**
  * Photo album deletion now restricted to performers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->