### PR TITLE
[FEAT] 등록자 확인용 직전 등록 공연 조회 api추가

### DIFF
--- a/src/main/java/cc/backend/amateurShow/controller/AmateurController.java
+++ b/src/main/java/cc/backend/amateurShow/controller/AmateurController.java
@@ -55,9 +55,18 @@ public class AmateurController {
     }
 
     @GetMapping("/{amateurShowId}")
-    @Operation(summary = "소극장 공연 조회 - 단건")
+    @Operation(summary = "승인된 소극장 공연 단건 조회 - 일반 사용자용")
     public ApiResponse<AmateurShowResponseDTO.AmateurShowResult> getAmateurShow(@PathVariable Long amateurShowId){
         return ApiResponse.onSuccess(amateurService.getAmateurShow(amateurShowId));
+    }
+
+    @PreAuthorize("hasRole('PERFORMER')")
+    @GetMapping("/created/{amateurShowId}")
+    @Operation(summary = "방금 등록한 공연 단건 조회(아직 미승인) - 등록자용")
+    public ApiResponse<AmateurShowResponseDTO.AmateurShowResult> getCreatedShow(
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @PathVariable Long amateurShowId){
+        return ApiResponse.onSuccess(amateurService.getCreatedShow(member.getId(), amateurShowId));
     }
 
     @GetMapping("/ranking")

--- a/src/main/java/cc/backend/amateurShow/converter/AmateurConverter.java
+++ b/src/main/java/cc/backend/amateurShow/converter/AmateurConverter.java
@@ -271,7 +271,7 @@ public class AmateurConverter {
                 //.place(amateurShow.getPlace())
                 .posterImageUrl(amateurShow.getPosterImageUrl())
                 .schedule(schedule)
-                .runtime(amateurShow.getRuntime())
+                .runtime(amateurShow.getRuntime() + "분")
                 .account(amateurShow.getAccount())
                 .contact(amateurShow.getContact())
                 .hashtag(amateurShow.getHashtag())

--- a/src/main/java/cc/backend/amateurShow/dto/AmateurEnrollRequestDTO.java
+++ b/src/main/java/cc/backend/amateurShow/dto/AmateurEnrollRequestDTO.java
@@ -27,7 +27,7 @@ public class AmateurEnrollRequestDTO {
     @NotNull(message = "종료 날짜는 필수입니다")
     private LocalDate end; // 공연 종료 날짜
 
-    private String runtime; // 러닝타임
+    private Integer runtime; // 러닝타임
     private String bankName; // 은행명
     private String account; // 계좌번호
     private String depositor; // 입금자명

--- a/src/main/java/cc/backend/amateurShow/dto/AmateurUpdateRequestDTO.java
+++ b/src/main/java/cc/backend/amateurShow/dto/AmateurUpdateRequestDTO.java
@@ -21,7 +21,7 @@ public class AmateurUpdateRequestDTO {
     //private String place; // 공연장 주소
     private LocalDate start; // 공연 시작 날짜
     private LocalDate end; // 공연 종료 날짜
-    private String runtime; // 러닝타임
+    private Integer runtime; // 러닝타임
     private String bankName; // 은행명
     private String account; // 계좌번호
     private String depositor; // 입금자명

--- a/src/main/java/cc/backend/amateurShow/entity/AmateurShow.java
+++ b/src/main/java/cc/backend/amateurShow/entity/AmateurShow.java
@@ -44,7 +44,7 @@ public class AmateurShow extends BaseEntity {
     private String depositor; // 입금자명
 
     // 추가
-    private String runtime;
+    private Integer runtime;
 
     private String hashtag;
 

--- a/src/main/java/cc/backend/amateurShow/repository/AmateurShowRepository.java
+++ b/src/main/java/cc/backend/amateurShow/repository/AmateurShowRepository.java
@@ -45,7 +45,7 @@ public interface AmateurShowRepository extends JpaRepository<AmateurShow, Long>,
             Pageable pageable
     );
 
-
+    Optional<AmateurShow> findByIdAndMemberId(Long id, Long memberId);
 
     Slice<AmateurShow> findByMember_IdOrderByIdDesc(Long memberId, Pageable pageable);
 

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurService.java
@@ -23,6 +23,7 @@ public interface AmateurService {
     List<AmateurShowResponseDTO.AmateurShowList> getShowRanking();
     List<AmateurShowResponseDTO.AmateurShowList> getRecentlyHotShow();
     List<AmateurShowResponseDTO.AmateurShowList> getShowClosing();
+    AmateurShowResponseDTO.AmateurShowResult getCreatedShow(Long memberId, Long amateurId);
 
 
     Slice<AmateurShowResponseDTO.MyShowAmateurShowList> getMyAmateurShow(Long memberId, AmateurShowStatus showStatus, Pageable pageable);

--- a/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
+++ b/src/main/java/cc/backend/amateurShow/service/amateurShowService/AmateurServiceImpl.java
@@ -447,6 +447,19 @@ public class AmateurServiceImpl implements AmateurService {
         AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
+        if(!amateurShow.getApprovalStatus().equals(ApprovalStatus.APPROVED)) {
+            throw new GeneralException((ErrorStatus.NOT_APPROVED_SHOW));
+        }
+
+        return AmateurConverter.toResponseDTO(amateurShow);
+    }
+
+    @Override
+    public AmateurShowResponseDTO.AmateurShowResult getCreatedShow(Long memberId, Long amateurShowId){
+        AmateurShow amateurShow =
+                amateurShowRepository.findByIdAndMemberId(amateurShowId, memberId)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_PERFORMER));
+
         return AmateurConverter.toResponseDTO(amateurShow);
     }
 

--- a/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -80,6 +80,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // AMATEURSHOW ERROR
     AMATEURSHOW_NOT_FOUND(HttpStatus.NOT_FOUND, "AMATEURSHOW4000", "존재하지 않는 소극장 공연입니다."),
     INVALID_DATE_RANGE(HttpStatus.NOT_ACCEPTABLE, "AMATEURSHOW4001", "공연 시작 날짜는 종료 날짜 이전이어햐 합니다."),
+    NOT_APPROVED_SHOW(HttpStatus.FORBIDDEN, "AMATEURSHOW4002", "승인되지 않은 소극장 공연입니다."),
+
 
     // AMATEUR TICKET ERROR
     AMATEUR_TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "AMATEURTICKET4000", "존재하지 않는 소극장 공연 티켓입니다."),


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - 방금 등록한 공연 (미승인) 단건 조회 api
    - 일반 사용자용 단건 조회는 승인된 공연만 보이도록 수정
    - 러닝타임 필드 String에서 Integer로 수정, 형식 고정후 dto에서 일괄적으로 "분" 붙여서 string으로 내려주도록
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Performers can now access a dedicated endpoint to retrieve detailed information about their created amateur shows
  * Runtime values in responses now display with time unit indicators (분 for minutes)

* **Improvements**
  * Access to amateur shows is now restricted based on approval status for general users
  * Requests for unapproved shows return appropriate error feedback
  * Existing endpoint documentation has been clarified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->