### PR TITLE
Feat/kakao account linking

### DIFF
--- a/src/main/java/cc/backend/auth/controller/AuthController.java
+++ b/src/main/java/cc/backend/auth/controller/AuthController.java
@@ -77,7 +77,7 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(Authentication authentication) {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        tokenProvider.logout(userDetails.getUsername());
+        tokenProvider.logout(userDetails.getMember().getId());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/cc/backend/auth/service/AuthService.java
+++ b/src/main/java/cc/backend/auth/service/AuthService.java
@@ -46,26 +46,18 @@ public class AuthService {
 
     private Member findOrCreateMember(KakaoUserInfo userInfo, Role role) {
         String email = userInfo.getKakaoAccount().getEmail();
-        String nickname = userInfo.getProperties().getNickname();
-        String name = userInfo.getKakaoAccount().getName();
-
-        String encryptedPhone = "";
-        try {
-            encryptedPhone = AESUtil.encrypt(userInfo.getKakaoAccount().getPhoneNumber());
-        } catch (Exception e) {
-            throw new GeneralException(ErrorStatus.PHONENUM_ENCRYPT_FAIL);
-        }
-
         String kakaoId = userInfo.getId().toString();
 
-       if (email == null || nickname == null || name == null || encryptedPhone == null)  {
-            log.error("필수 정보 누락 - 이메일: {}, 닉네임: {}, 이름: {}, 전화번호: {}",
-                    email, nickname, name, encryptedPhone);
-            throw new GeneralException(ErrorStatus.INVALID_KAKAO_USER_INFO);
+        // 1차: kakaoId로 조회
+        Optional<Member> existingMember = memberRepository.findMemberByKakaoId(kakaoId);
+
+        // 2차: 카카오가 아니라 이메일로 가입한 기존 회원 조회
+        if (existingMember.isEmpty() && email != null) {
+            log.info("kakaoId로 회원 미발견, email로 2차 조회: {}", email);
+            existingMember = memberRepository.findMemberByEmail(email);
         }
 
-        Optional<Member> existingMember = memberRepository.findMemberByEmail(email);
-
+        //기존 멤버인 경우 먼저 반환
         if (existingMember.isPresent()) {
             Member member = existingMember.get();
 
@@ -76,7 +68,7 @@ public class AuthService {
                     throw new GeneralException(ErrorStatus.MEMBER_ROLE_ALREADY_EXISTS);
                 }
 
-                //같은 역할일 경우 로그인 처리
+                //기존 계정이 이메일로만 가입한 경우 kakaoId 자동 연동
                 if (member.getKakaoId() == null) {
                     member.updateKakaoId(kakaoId);
                 }
@@ -91,13 +83,10 @@ public class AuthService {
 
         }
 
-        return createNewMember(userInfo, role, kakaoId);
-    }
-
-    private Member createNewMember(KakaoUserInfo userInfo, Role role, String kakaoId) {
-        String email = userInfo.getKakaoAccount().getEmail();
+        // 기존 멤버가 아닌 경우 새 맴버 생성
         String nickname = userInfo.getProperties().getNickname();
         String name = userInfo.getKakaoAccount().getName();
+
         String encryptedPhone = "";
         try {
             encryptedPhone = AESUtil.encrypt(userInfo.getKakaoAccount().getPhoneNumber());
@@ -105,6 +94,19 @@ public class AuthService {
             throw new GeneralException(ErrorStatus.PHONENUM_ENCRYPT_FAIL);
         }
 
+        if (email == null || nickname == null || name == null)  {
+            log.error("필수 정보 누락 - 이메일: {}, 닉네임: {}, 이름: {}, 전화번호: {}",
+                    email, nickname, name, encryptedPhone);
+            throw new GeneralException(ErrorStatus.INVALID_KAKAO_USER_INFO);
+        }
+
+        return createNewMember(userInfo, role, kakaoId, encryptedPhone);
+    }
+
+    private Member createNewMember(KakaoUserInfo userInfo, Role role, String kakaoId, String encryptedPhone) {
+        String email = userInfo.getKakaoAccount().getEmail();
+        String nickname = userInfo.getProperties().getNickname();
+        String name = userInfo.getKakaoAccount().getName();
         String username = generateUsername(nickname);
 
         Member newMember = Member.builder()
@@ -155,7 +157,7 @@ public class AuthService {
             throw new GeneralException(ErrorStatus.PHONENUM_ENCRYPT_FAIL);
         }
 
-            // 회원 정보 업데이트 및 재활성화
+        // 회원 정보 업데이트 및 재활성화
         member.reactivateMember();
         member.updateRole(newRole); // 역할 업데이트
         member.updateName(name);

--- a/src/main/java/cc/backend/auth/service/AuthService.java
+++ b/src/main/java/cc/backend/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import cc.backend.member.repository.MemberRepository;
 import cc.backend.member.util.AESUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,10 +52,28 @@ public class AuthService {
         // 1차: kakaoId로 조회
         Optional<Member> existingMember = memberRepository.findMemberByKakaoId(kakaoId);
 
-        // 2차: 카카오가 아니라 이메일로 가입한 기존 회원 조회
+        // 2차: kakaoId에 해당하는 계정 없는 경우, 이메일 대조로 기존 회원 조회
         if (existingMember.isEmpty() && email != null) {
             log.info("kakaoId로 회원 미발견, email로 2차 조회: {}", email);
-            existingMember = memberRepository.findMemberByEmail(email);
+            Optional<Member> emailMember = memberRepository.findMemberByEmail(email);
+
+            if (emailMember.isPresent()) {
+                Member member = emailMember.get();
+
+                //같은 이메일이 등록된 서로 다른 kakao계정 존재(A,B)
+                // A계정으로 서비스 가입,
+                // B계정으로 로그인 시도할 경우, B의 kakaoId가 없어 이메일로 로그인 시도
+                // 해당 이메일로 멤버 조회시 기존 계정인 A가 반환
+                // A와 연결된 멤버의 kakaoId가 B로 바뀌는 email fallback으로 우회 로그인 문제 발생 가능
+                // 우회 로그인 에러 던짐
+                if (member.getKakaoId() != null && !member.getKakaoId().equals(kakaoId)) {
+                    log.warn("Email fallback blocked. email={}, existingKakaoId={}, loginKakaoId={}",
+                            email, member.getKakaoId(), kakaoId);
+                    throw new GeneralException(ErrorStatus.INVALID_KAKAO_USER_INFO);
+                }
+                existingMember = emailMember;   // 🔥 이거 필요
+
+            }
         }
 
         //기존 멤버인 경우 먼저 반환
@@ -87,7 +106,7 @@ public class AuthService {
         String nickname = userInfo.getProperties().getNickname();
         String name = userInfo.getKakaoAccount().getName();
 
-        String encryptedPhone = "";
+        String encryptedPhone;
         try {
             encryptedPhone = AESUtil.encrypt(userInfo.getKakaoAccount().getPhoneNumber());
         } catch (Exception e) {
@@ -118,7 +137,34 @@ public class AuthService {
                 .kakaoId(kakaoId)
                 .build();
 
-        return memberRepository.save(newMember);
+        //멱등성 문제 방지(duplicate-write handling)
+        try {
+            return memberRepository.save(newMember);
+
+        } catch (DataIntegrityViolationException e) {
+            //동시에 들어온 두번째 요청이 save실패 후 catch 구문으로 빠져 첫 요청으로 생성된 멤버를 반환하도록
+            log.warn("Concurrent kakao signup detected. retry lookup. kakaoId={}", kakaoId);
+
+            Optional<Member> kakaoMember = memberRepository.findMemberByKakaoId(kakaoId);
+            if (kakaoMember.isPresent()) {
+                return kakaoMember.get();
+            }
+
+            if (email != null) {
+                Optional<Member> emailMember = memberRepository.findMemberByEmail(email);
+                if (emailMember.isPresent()) {
+                    Member member = emailMember.get();
+                    // email fallback은 kakaoId가 없는 계정에만 허용
+                    // 이메일 가입 계정만 허용
+                    if (member.getKakaoId() == null) {
+                        member.updateKakaoId(kakaoId);
+                        return member;
+                    }
+                }
+            }
+
+            throw e;
+        }
     }
 
     //유저네임 = 닉네임 + 랜덤숫자 3개
@@ -150,7 +196,7 @@ public class AuthService {
         String nickname = userInfo.getProperties().getNickname();
         String newUsername = generateUsername(nickname);
 
-        String encryptedPhone = "";
+        String encryptedPhone;
         try {
             encryptedPhone = AESUtil.encrypt(userInfo.getKakaoAccount().getPhoneNumber());
         } catch (Exception e) {
@@ -164,11 +210,21 @@ public class AuthService {
         member.updateUsername(newUsername);
         member.updatePhone(encryptedPhone);
 
+        // CASE 1: 기존 계정이 이메일로만 가입되어 kakaoId가 없는 경우
+        // → 현재 로그인한 kakaoId를 연결하여 계정을 재활성화
         if (member.getKakaoId() == null) {
             member.updateKakaoId(kakaoId);
+        } else if (!member.getKakaoId().equals(kakaoId)) {
+            // CASE 2: 기존 계정에 이미 kakaoId가 연결되어 있지만,
+            // 로그인 시도한 kakaoId와 다른 경우
+            // → email fallback을 통한 계정 탈취 가능성이 있으므로 로그인 차단
+            log.warn("Reactivation blocked. memberId={}, existingKakaoId={}, loginKakaoId={}",
+                    member.getId(), member.getKakaoId(), kakaoId);
+            throw new GeneralException(ErrorStatus.INVALID_KAKAO_USER_INFO);
         }
 
-
+        // CASE 3: 기존 계정의 kakaoId와 현재 로그인한 kakaoId가 동일한 경우
+        // → 정상적인 재로그인이므로 추가 처리 없이 그대로 진행
         return member;
     }
 }

--- a/src/main/java/cc/backend/config/jwt/RefreshTokenService.java
+++ b/src/main/java/cc/backend/config/jwt/RefreshTokenService.java
@@ -14,32 +14,32 @@ public class RefreshTokenService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;
+    private static final Duration REFRESH_TOKEN_EXPIRE_TIME = Duration.ofDays(7);
 
     // 리프레시 토큰 저장
-    public void saveRefreshToken(String email, String refreshToken) {
-        String key = REFRESH_TOKEN_PREFIX + email;
-        redisTemplate.opsForValue().set(key, refreshToken, Duration.ofSeconds(REFRESH_TOKEN_EXPIRE_TIME));
-        log.debug("리프레시 토큰 저장 완료 - 사용자: {}", email);
+    public void saveRefreshToken(Long memberId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + memberId;
+        redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
+        log.debug("리프레시 토큰 저장 완료 - 사용자: {}", memberId);
     }
 
     // 리프레시 토큰 조회
-    public String getRefreshToken(String email) {
-        String key = REFRESH_TOKEN_PREFIX + email;
+    public String getRefreshToken(Long memberId) {
+        String key = REFRESH_TOKEN_PREFIX + memberId;
         Object token = redisTemplate.opsForValue().get(key);
         return token != null ? token.toString() : null;
     }
 
     // 리프레시 토큰 검증
-    public boolean validateRefreshToken(String email, String refreshToken) {
-        String savedToken = getRefreshToken(email);
+    public boolean validateRefreshToken(Long memberId, String refreshToken) {
+        String savedToken = getRefreshToken(memberId);
         return savedToken != null && savedToken.equals(refreshToken);
     }
 
     // 리프레시 토큰 삭제 (로그아웃 시)
-    public void deleteRefreshToken(String email) {
-        String key = REFRESH_TOKEN_PREFIX + email;
+    public void deleteRefreshToken(Long memberId) {
+        String key = REFRESH_TOKEN_PREFIX + memberId;
         redisTemplate.delete(key);
-        log.debug("리프레시 토큰 삭제 완료 - 사용자: {}", email);
+        log.debug("리프레시 토큰 삭제 완료 - 사용자: {}", memberId);
     }
 }

--- a/src/main/java/cc/backend/config/jwt/TokenProvider.java
+++ b/src/main/java/cc/backend/config/jwt/TokenProvider.java
@@ -26,15 +26,14 @@ import java.util.Date;
 public class TokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 5;            // 5시간
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 5;            //ms단위: 5시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  //ms단위: 7일
 
     private final MemberRepository memberRepository;
     private final RefreshTokenService refreshTokenService;
     private final Key key;
 
     public TokenProvider(@Value("${jwt.secret}") String secretKey, MemberRepository memberRepository,RefreshTokenService refreshTokenService) {
-        log.info("JWT Secret Key (Generation): {}", secretKey); // Secret Key 출력
 
         this.memberRepository = memberRepository;
         this.refreshTokenService = refreshTokenService;
@@ -43,38 +42,50 @@ public class TokenProvider {
     }
 
     public TokenDTO generateTokenDto(Member member) {
-        long now = System.currentTimeMillis();
-
         // Access Token 생성
-        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
-        String accessToken = Jwts.builder()
-                .setSubject(member.getEmail())      // payload "sub": "name"
-                .claim(AUTHORITIES_KEY, "ROLE_" + member.getRole().name())        // payload "auth": "ROLE_USER"
-                .setExpiration(accessTokenExpiresIn)        // payload "exp": 151621022 (ex)
-                .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
-                .compact();
+        String accessToken = createAccessToken(member);
 
         // Refresh Token 생성
-        String refreshToken = Jwts.builder()
-                .setSubject(member.getEmail())
-                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
-                .signWith(key, SignatureAlgorithm.HS512)
-                .compact();
+        String refreshToken = createRefreshToken(member);
 
-        refreshTokenService.saveRefreshToken(member.getEmail(), refreshToken);
+        refreshTokenService.saveRefreshToken(member.getId(), refreshToken);
 
         return TokenDTO.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
     }
+
+    private String createAccessToken(Member member) {
+        long now = System.currentTimeMillis();
+
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(member.getId()))  // payload "sub": "id"
+                .claim(AUTHORITIES_KEY, "ROLE_" + member.getRole().name()) // payload "auth": "ROLE_USER"
+                .setExpiration(accessTokenExpiresIn)    // payload "exp": 151621022 (ex)
+                .signWith(key, SignatureAlgorithm.HS512)     // header "alg": "HS512"
+                .compact();
+    }
+
+    private String createRefreshToken(Member member) {
+        long now = System.currentTimeMillis();
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(member.getId()))
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
     public Authentication getAuthentication(String accessToken) {
         Claims claims = parseClaims(accessToken);
 
-        String email = claims.getSubject();
+        Long memberId = Long.valueOf(claims.getSubject());
 
         // Member 조회
-        Member member = memberRepository.findMemberByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 활성 상태 확인
@@ -91,7 +102,6 @@ public class TokenProvider {
 
 
     public boolean validateToken(String token) {
-        log.info("JWT Secret Key (Validation): {}", Base64.getEncoder().encodeToString(key.getEncoded())); // Secret Key 출력
 
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
@@ -122,19 +132,24 @@ public class TokenProvider {
         }
 
         Claims claims = parseClaims(refreshToken);
-        String email = claims.getSubject();
+        Long memberId = Long.valueOf(claims.getSubject());
 
-        if (!refreshTokenService.validateRefreshToken(email, refreshToken)) {
+        if (!refreshTokenService.validateRefreshToken(memberId, refreshToken)) {
             throw new GeneralException(ErrorStatus.INVALID_REFRESH_TOKEN);
         }
 
-        Member member = memberRepository.findMemberByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        return generateTokenDto(member);
+        String newAccessToken = createAccessToken(member);
+
+        return TokenDTO.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(refreshToken) //전에 발급받은 refreshToken은 그대로 유지
+                .build();
     }
 
-    public void logout(String email) {
-        refreshTokenService.deleteRefreshToken(email);
+    public void logout(Long memberId) {
+        refreshTokenService.deleteRefreshToken(memberId);
     }
 }

--- a/src/main/java/cc/backend/member/entity/Member.java
+++ b/src/main/java/cc/backend/member/entity/Member.java
@@ -52,7 +52,7 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ActiveStatus active_status;
 
-    @Column(name = "kakao_id")
+    @Column(name = "kakao_id", unique = true) //createMember() 멱등성을 위해 unique 보장
     private String kakaoId;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/cc/backend/member/repository/MemberRepository.java
+++ b/src/main/java/cc/backend/member/repository/MemberRepository.java
@@ -18,6 +18,8 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     @Query("select m from Member m where m.email = :email")
     Optional<Member> findMemberByEmail(@Param("email") String email);
 
+    Optional<Member> findMemberByKakaoId(String kakaoId);
+
     Page<Member> findByUsernameContainingIgnoreCase(String username, Pageable pageable);
 
     boolean existsByUsername(String username);

--- a/src/main/java/cc/backend/notice/entity/enums/NoticeType.java
+++ b/src/main/java/cc/backend/notice/entity/enums/NoticeType.java
@@ -1,5 +1,5 @@
 package cc.backend.notice.entity.enums;
 
 public enum NoticeType {
-    AMATEURSHOW, HOT, COMMENT, REPLY, TICKET, REMIND, AD
+    AMATEURSHOW, HOT, COMMENT, REPLY, TICKET, REMIND, RECOMMEND
 }


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - 	카카오 로그인 로직에서 기존 회원 반환 시점을 앞으로 당겨, 기존 회원인 경우 불필요한 추가 로직이 수행되지 않도록 효율화
    - 기존 멤버 조회 기준을 email에서 kakaoId 중심으로 변경하고, 필요 시 email을 통한 2차 조회가 가능하도록 수정
    - TokenProvider와 RefreshTokenService 간 TTL 단위 불일치로 인해 Redis에 refresh token이 비정상적으로 길게 저장되던 문제를 수정
        - ms 단위 상수를 초 단위 TTL로 잘못 사용하면서 약 19년짜리 토큰이 저장되던 문제를 해결했습니다.

3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kakao ID-based member lookup and improved account linking with Kakao logins.
  * Improved handling for creating or reactivating accounts when Kakao information is present.

* **Bug Fixes**
  * Logout and token handling now operate by member ID for more reliable session management.
  * Added safeguards to prevent incorrect account linking and handle duplicate-write races.

* **Refactor**
  * Token and authentication flows migrated from email-based to ID-based keys.
  * Notice type renamed from "AD" to "RECOMMEND".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->