### PR TITLE
[FIX] restrict dev auth endpoints to non-prod profiles

### DIFF
--- a/src/main/java/cc/backend/auth/controller/AuthController.java
+++ b/src/main/java/cc/backend/auth/controller/AuthController.java
@@ -4,19 +4,12 @@ package cc.backend.auth.controller;
 import cc.backend.config.jwt.CustomUserDetails;
 import cc.backend.config.jwt.dto.TokenDTO;
 import cc.backend.config.jwt.TokenProvider;
-import cc.backend.config.jwt.dto.RefreshTokenRequest;
-import cc.backend.member.entity.Member;
-import cc.backend.member.repository.MemberRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.util.Set;
 
 @Tag(name = "Auth", description = "Auth API")
 @RestController
@@ -25,52 +18,7 @@ import java.util.Set;
 public class AuthController {
 
     private final TokenProvider tokenProvider;
-    private final MemberRepository memberRepository;
 
-    // 허용된 dev 계정 목록
-    private static final Set<String> ALLOWED_EMAILS = Set.of(
-            "user@test.com",
-            "performer@test.com",
-            "admin@test.com"
-    );
-
-    @Operation(
-            summary = "개발자용 토큰 발급",
-            description = """
-            개발/테스트 환경에서만 사용할 수 있는 토큰 발급 API입니다.
-            <br><br>
-            <b>허용된 계정만 사용 가능합니다.</b><br>
-            - user@test.com<br>
-            - performer@test.com<br>
-            - admin@test.com
-            """
-    )
-    @PostMapping("/dev/login")
-    public ResponseEntity<TokenDTO> devLogin(
-            @RequestParam String email
-    ) {
-        // 화이트리스트 체크
-        if (!ALLOWED_EMAILS.contains(email)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "허용되지 않은 계정입니다.");
-        }
-
-        Member member = memberRepository.findMemberByEmail(email)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "계정이 존재하지 않습니다."));
-
-        TokenDTO tokenDto = tokenProvider.generateTokenDto(member);
-
-        return ResponseEntity.ok(tokenDto);
-    }
-
-    @Operation(
-            summary = "개발자용 액세스 토큰 재발급",
-            description = "refresh token을 통해 access token을 재발급합니다."
-    )
-    @PostMapping("/dev/refresh")
-    public ResponseEntity<TokenDTO> refresh(@RequestBody RefreshTokenRequest request) {
-        TokenDTO tokenDto = tokenProvider.refreshAccessToken(request.getRefreshToken());
-        return ResponseEntity.ok(tokenDto);
-    }
     @Operation(
             summary = "로그아웃"
     )

--- a/src/main/java/cc/backend/auth/controller/DevAuthController.java
+++ b/src/main/java/cc/backend/auth/controller/DevAuthController.java
@@ -1,0 +1,71 @@
+package cc.backend.auth.controller;
+
+import cc.backend.config.jwt.TokenProvider;
+import cc.backend.config.jwt.dto.RefreshTokenRequest;
+import cc.backend.config.jwt.dto.TokenDTO;
+import cc.backend.member.entity.Member;
+import cc.backend.member.repository.MemberRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Set;
+
+@Tag(name = "Auth", description = "Auth API")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Profile({"local", "dev"})
+public class DevAuthController {
+
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+
+    // 허용된 dev 계정 목록
+    private static final Set<String> ALLOWED_EMAILS = Set.of(
+            "user@test.com",
+            "performer@test.com",
+            "admin@test.com"
+    );
+
+    @Operation(
+            summary = "개발자용 토큰 발급",
+            description = """
+            개발/테스트 환경에서만 사용할 수 있는 토큰 발급 API입니다.
+            <br><br>
+            <b>허용된 계정만 사용 가능합니다.</b><br>
+            - user@test.com<br>
+            - performer@test.com<br>
+            - admin@test.com
+            """
+    )
+    @PostMapping("/dev/login")
+    public ResponseEntity<TokenDTO> devLogin(
+            @RequestParam String email
+    ) {
+        if (!ALLOWED_EMAILS.contains(email)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "허용되지 않은 계정입니다.");
+        }
+
+        Member member = memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "계정이 존재하지 않습니다."));
+
+        TokenDTO tokenDto = tokenProvider.generateTokenDto(member);
+        return ResponseEntity.ok(tokenDto);
+    }
+
+    @Operation(
+            summary = "개발자용 액세스 토큰 재발급",
+            description = "refresh token을 통해 access token을 재발급합니다."
+    )
+    @PostMapping("/dev/refresh")
+    public ResponseEntity<TokenDTO> refresh(@RequestBody RefreshTokenRequest request) {
+        TokenDTO tokenDto = tokenProvider.refreshAccessToken(request.getRefreshToken());
+        return ResponseEntity.ok(tokenDto);
+    }
+}

--- a/src/main/java/cc/backend/auth/controller/DevAuthController.java
+++ b/src/main/java/cc/backend/auth/controller/DevAuthController.java
@@ -20,7 +20,7 @@ import java.util.Set;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-@Profile({"local", "dev"})
+@Profile("(local | dev) & !prod")
 public class DevAuthController {
 
     private final TokenProvider tokenProvider;


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 없음

2. **📝 작업 내용**
    - 운영 환경에서 개발용 토큰 발급 엔드포인트가 노출되지 않도록 수정했습니다.
    - 기존 `AuthController`에 있던 `/auth/dev/login`, `/auth/dev/refresh` 로직을 `DevAuthController`로 분리했습니다.
    - `DevAuthController`에 `@Profile({"local", "dev"})`를 적용하여 `prod` profile에서는 해당 컨트롤러가 등록되지 않도록 했습니다.
    - Google/Kakao OAuth, logout, JWT 발급/검증, Redis refresh token 저장 구조는 변경하지 않았습니다.

    **검증**
    - `JAVA_HOME`을 JDK 17로 설정 후 `./gradlew compileJava --no-daemon` 실행
    - 결과: `BUILD SUCCESSFUL`

3. **📸 스크린샷 (선택)**
    - 없음

4. **💬 리뷰 요구사항 (선택)**
    - `local/dev` profile에서는 `/auth/dev/login`, `/auth/dev/refresh`가 기존처럼 사용 가능하고, `prod` profile에서는 `DevAuthController`가 등록되지 않는 구조가 적절한지 확인 부탁드립니다.
    - `SecurityConfig`는 변경하지 않고 컨트롤러 profile 분리만 적용했는데, 이 정도 범위가 현재 단계에서 충분한지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Developer authentication endpoints for login and token refresh have been reorganized into a separate dedicated controller that operates exclusively in local and development environments. All existing developer functionality is completely preserved. Production and core application authentication behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->