### PR TITLE
[FIX] 관리자 권한 비교 로직 수정

### DIFF
--- a/src/main/java/cc/backend/admin/account/AdminAccountService.java
+++ b/src/main/java/cc/backend/admin/account/AdminAccountService.java
@@ -4,6 +4,7 @@ import cc.backend.admin.account.dto.AccountRequest;
 import cc.backend.admin.account.dto.AccountResponse;
 import cc.backend.member.entity.Account;
 import cc.backend.member.entity.Member;
+import cc.backend.member.enumerate.Role;
 import cc.backend.member.repository.AccountRepository;
 import cc.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -79,7 +80,7 @@ public class AdminAccountService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        if (!member.getRole().equals("ADMIN")) {
+        if (!Role.ADMIN.equals(member.getRole())) {
             throw new IllegalStateException("관리자 권한이 필요합니다.");
         }
     }

--- a/src/test/java/cc/backend/admin/account/AdminAccountServiceTest.java
+++ b/src/test/java/cc/backend/admin/account/AdminAccountServiceTest.java
@@ -1,0 +1,86 @@
+package cc.backend.admin.account;
+
+import cc.backend.admin.account.dto.AccountRequest;
+import cc.backend.admin.account.dto.AccountResponse;
+import cc.backend.member.entity.Account;
+import cc.backend.member.entity.Member;
+import cc.backend.member.enumerate.Role;
+import cc.backend.member.repository.AccountRepository;
+import cc.backend.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAccountServiceTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private AdminAccountService adminAccountService;
+
+    @Test
+    void createAccount_throwsWhenMemberIsNotAdmin() {
+        Long memberId = 1L;
+        Member audience = Member.builder()
+                .email("audience@test.com")
+                .role(Role.AUDIENCE)
+                .build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(audience));
+
+        AccountRequest request = AccountRequest.builder()
+                .bankName("bank")
+                .accountNumber("123-456")
+                .accountOwner("owner")
+                .build();
+
+        assertThrows(IllegalStateException.class, () -> adminAccountService.createAccount(memberId, request));
+    }
+
+    @Test
+    void createAccount_succeedsWhenMemberIsAdmin() {
+        Long memberId = 1L;
+        Member admin = Member.builder()
+                .email("admin@test.com")
+                .role(Role.ADMIN)
+                .build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(admin));
+        when(memberRepository.existsById(memberId)).thenReturn(true);
+        when(accountRepository.save(any(Account.class))).thenReturn(
+                Account.builder()
+                        .id(10L)
+                        .bankName("bank")
+                        .accountNumber("123-456")
+                        .accountOwner("owner")
+                        .memberId(memberId)
+                        .build()
+        );
+
+        AccountRequest request = AccountRequest.builder()
+                .bankName("bank")
+                .accountNumber("123-456")
+                .accountOwner("owner")
+                .build();
+
+        AccountResponse response = adminAccountService.createAccount(memberId, request);
+
+        assertEquals(10L, response.getId());
+        assertEquals(memberId, response.getMemberId());
+        assertEquals("bank", response.getBankName());
+    }
+}

--- a/src/test/java/cc/backend/admin/account/AdminAccountServiceTest.java
+++ b/src/test/java/cc/backend/admin/account/AdminAccountServiceTest.java
@@ -52,6 +52,25 @@ class AdminAccountServiceTest {
     }
 
     @Test
+    void createAccount_throwsWhenMemberRoleIsNull() {
+        Long memberId = 1L;
+        Member memberWithNullRole = Member.builder()
+                .email("null-role@test.com")
+                .role(null)
+                .build();
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberWithNullRole));
+
+        AccountRequest request = AccountRequest.builder()
+                .bankName("bank")
+                .accountNumber("123-456")
+                .accountOwner("owner")
+                .build();
+
+        assertThrows(IllegalStateException.class, () -> adminAccountService.createAccount(memberId, request));
+    }
+
+    @Test
     void createAccount_succeedsWhenMemberIsAdmin() {
         Long memberId = 1L;
         Member admin = Member.builder()
@@ -82,5 +101,7 @@ class AdminAccountServiceTest {
         assertEquals(10L, response.getId());
         assertEquals(memberId, response.getMemberId());
         assertEquals("bank", response.getBankName());
+        assertEquals("123-456", response.getAccountNumber());
+        assertEquals("owner", response.getAccountOwner());
     }
 }


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 없음

2. **📝 작업 내용**
    - `AdminAccountService`에서 관리자 권한을 확인할 때 enum 타입인 `Role`과 문자열 `"ADMIN"`을 비교하던 문제를 수정했습니다.
    - 기존 `member.getRole().equals("ADMIN")` 비교를 `Role.ADMIN.equals(member.getRole())`로 변경했습니다.
    - `member.getRole()`이 null인 경우에도 NPE 없이 false로 처리되도록 했습니다.
    - 프로젝트 내 동일한 enum/String role 비교 패턴이 있는지 확인했으며, 동일한 명확한 버그는 추가로 발견되지 않았습니다.
    - `AdminAccountServiceTest`를 추가하여 관리자/비관리자 케이스를 검증했습니다.

    **검증**
    - `JAVA_HOME`을 JDK 17로 설정 후 아래 테스트를 실행했습니다.
    - `./gradlew test --tests cc.backend.admin.account.AdminAccountServiceTest --no-daemon`
    - 결과: `BUILD SUCCESSFUL`

3. **📸 스크린샷 (선택)**
    - 없음

4. **💬 리뷰 요구사항 (선택)**
    - `Role.ADMIN.equals(member.getRole())` 방식으로 관리자 권한 비교를 수정한 것이 현재 `Role` enum 구조에 적절한지 확인 부탁드립니다.
    - 추가한 `AdminAccountServiceTest`의 관리자/비관리자 검증 케이스가 충분한지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved admin privilege validation to use standardized role checks for more reliable access control.

* **Tests**
  * Added unit tests covering admin account creation: unauthorized access, missing role, and successful creation with expected account details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->