### PR TITLE
[FIX] KakaoPay ready 요청 인증 처리

### DIFF
--- a/src/main/java/cc/backend/config/jwt/SecurityConfig.java
+++ b/src/main/java/cc/backend/config/jwt/SecurityConfig.java
@@ -65,7 +65,8 @@ public class SecurityConfig {
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/auth/**").permitAll()
 
-                        .requestMatchers("/kakaoPay/**").permitAll() // 카카오페이 관련 API 허용
+                        .requestMatchers(HttpMethod.GET, "/kakaoPay/approve", "/kakaoPay/cancel", "/kakaoPay/fail").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/kakaoPay/ready").authenticated()
 
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()
@@ -106,4 +107,3 @@ public class SecurityConfig {
         """);
     }
 }
-

--- a/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
+++ b/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
@@ -9,8 +9,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 
@@ -29,6 +31,9 @@ public class KakaoPayController {
     @Operation(summary = "카카오페이 결제 준비", description = "카카오페이 결제창 URL을 발급합니다.")
     public ApiResponse<KakaoPayReadyResponseDTO> preparePayment(@RequestParam Long tempTicketId,
                                                        @AuthenticationPrincipal(expression = "member") Member member) {
+        if (member == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         return ApiResponse.onSuccess(kakaoPayBusinessService.preparePayment(tempTicketId, String.valueOf(member.getId())));
     }
 


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 없음

2. **📝 작업 내용**
    - `/kakaoPay/**` 전체를 `permitAll`로 열어두던 설정을 endpoint 단위로 분리했습니다.
    - FE에서 로그인 사용자가 직접 호출하는 `POST /kakaoPay/ready`는 인증된 사용자만 호출할 수 있도록 변경했습니다.
    - 카카오페이 redirect/callback 성격의 `GET /kakaoPay/approve`, `GET /kakaoPay/cancel`, `GET /kakaoPay/fail`은 기존처럼 `permitAll`을 유지했습니다.
    - `KakaoPayController`의 `/ready`에서 `member == null`인 경우 NPE가 아니라 `401 Unauthorized`가 발생하도록 방어 코드를 추가했습니다.
    - 결제 redirect 흐름, 외부 KakaoPay API 호출, TempTicket/RealTicket 생성 로직은 변경하지 않았습니다.

3. **📸 스크린샷 (선택)**
    - 없음

4. **💬 리뷰 요구사항 (선택)**
    - `POST /kakaoPay/ready`만 인증 필요로 변경하고, `GET /kakaoPay/approve`, `GET /kakaoPay/cancel`, `GET /kakaoPay/fail`은 공개 유지한 보안 설정이 결제 redirect 흐름에 적절한지 확인 부탁드립니다.
    - `member == null`일 때 `401 Unauthorized`를 반환하는 방식이 현재 프로젝트의 예외 처리 방식과 맞는지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted KakaoPay endpoint access to specific payment operations (approval, cancellation, failure handling).
  * Enforced user authentication requirement for payment preparation to prevent unauthorized payment initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->