### PR TITLE
[FIX] RealTicket 중복 생성 방지

### DIFF
--- a/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
+++ b/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
@@ -91,6 +91,11 @@ public class KakaoPayBusinessService {
             throw new GeneralException(ErrorStatus.TEMP_TICKET_TID_NOT_FOUND);
         }
 
+        Long amateurShowId = tempTicket.getAmateurTicket().getAmateurShow().getId();
+        if (isRealTicketAlreadyIssued(tempTicket)) {
+            return new KakaoPayResultResponseDTO(amateurShowId, null);
+        }
+
         // 멤버를 DB에서 추적하기
         String partnerUserId = tempTicket.getMember().getId().toString();
         KakaoPayApproveResponseDTO responseDTO;
@@ -119,13 +124,19 @@ public class KakaoPayBusinessService {
 
         // 예약 확정 및 최종 티켓 생성
         confirmReservation(tempTicket);
-        realTicketService.createRealTicketFromTempTicket(tempTicket);
+        if (!isRealTicketAlreadyIssued(tempTicket)) {
+            realTicketService.createRealTicketFromTempTicket(tempTicket);
+        }
 
-        Long amateurShowId = tempTicket.getAmateurTicket().getAmateurShow().getId();
         return new KakaoPayResultResponseDTO(
                 amateurShowId,
                 responseDTO
         );
+    }
+
+    private boolean isRealTicketAlreadyIssued(TempTicket tempTicket) {
+        return tempTicket.getKakaoTid() != null
+                && realTicketRepository.existsByKakaoTid(tempTicket.getKakaoTid());
     }
 
     private void confirmReservation(TempTicket tempTicket) {

--- a/src/main/java/cc/backend/ticket/repository/RealTicketRepository.java
+++ b/src/main/java/cc/backend/ticket/repository/RealTicketRepository.java
@@ -26,6 +26,8 @@ public interface RealTicketRepository extends JpaRepository<RealTicket, Long> {
 
     Slice<RealTicket> findAllByMemberIdAndReservationStatus(Long memberId, ReservationStatus reservationStatus, Pageable pageable);
 
+    boolean existsByKakaoTid(String kakaoTid);
+
     List<RealTicket> findByShowTitleAndReservationStatusInOrderByIdDesc(
             String showTitle,
             List<ReservationStatus> statuses

--- a/src/test/java/cc/backend/kakaoPay/service/KakaoPayBusinessServiceTest.java
+++ b/src/test/java/cc/backend/kakaoPay/service/KakaoPayBusinessServiceTest.java
@@ -1,0 +1,135 @@
+package cc.backend.kakaoPay.service;
+
+import cc.backend.amateurShow.entity.AmateurRounds;
+import cc.backend.amateurShow.entity.AmateurShow;
+import cc.backend.amateurShow.entity.AmateurTicket;
+import cc.backend.amateurShow.repository.AmateurRoundsRepository;
+import cc.backend.kakaoPay.dto.responseDTO.KakaoPayApproveResponseDTO;
+import cc.backend.kakaoPay.dto.responseDTO.KakaoPayResultResponseDTO;
+import cc.backend.member.entity.Member;
+import cc.backend.ticket.entity.TempTicket;
+import cc.backend.ticket.entity.enums.ReservationStatus;
+import cc.backend.ticket.repository.RealTicketRepository;
+import cc.backend.ticket.repository.TempTicketRepository;
+import cc.backend.ticket.service.RealTicketService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoPayBusinessServiceTest {
+
+    @Mock
+    private TempTicketRepository tempTicketRepository;
+
+    @Mock
+    private AmateurRoundsRepository amateurRoundsRepository;
+
+    @Mock
+    private RealTicketService realTicketService;
+
+    @Mock
+    private RealTicketRepository realTicketRepository;
+
+    @Mock
+    private KakaoPayService kakaoPayService;
+
+    @InjectMocks
+    private KakaoPayBusinessService kakaoPayBusinessService;
+
+    @Test
+    void completePayment_createsRealTicketOnFirstApproval() {
+        TempTicket tempTicket = createTempTicket(ReservationStatus.PENDING);
+        KakaoPayApproveResponseDTO approveResponse = KakaoPayApproveResponseDTO.builder()
+                .tid("tid-1")
+                .partnerOrderId("1")
+                .partnerUserId("10")
+                .build();
+
+        when(tempTicketRepository.findWithTicketAndShowById(1L)).thenReturn(Optional.of(tempTicket));
+        when(realTicketRepository.existsByKakaoTid("tid-1")).thenReturn(false);
+        when(kakaoPayService.approve("tid-1", "1", "10", "pg-token")).thenReturn(approveResponse);
+
+        KakaoPayResultResponseDTO result = kakaoPayBusinessService.completePayment("1", "pg-token");
+
+        assertEquals(100L, result.getAmateurShowId());
+        assertEquals(approveResponse, result.getApproveResponse());
+        assertEquals(ReservationStatus.RESERVED, tempTicket.getReservationStatus());
+        verify(kakaoPayService).approve("tid-1", "1", "10", "pg-token");
+        verify(realTicketService).createRealTicketFromTempTicket(tempTicket);
+    }
+
+    @Test
+    void completePayment_doesNotCreateRealTicketWhenApprovalIsRetried() {
+        TempTicket tempTicket = createTempTicket(ReservationStatus.RESERVED);
+
+        when(tempTicketRepository.findWithTicketAndShowById(1L)).thenReturn(Optional.of(tempTicket));
+        when(realTicketRepository.existsByKakaoTid("tid-1")).thenReturn(true);
+
+        KakaoPayResultResponseDTO result = kakaoPayBusinessService.completePayment("1", "pg-token");
+
+        assertEquals(100L, result.getAmateurShowId());
+        assertNull(result.getApproveResponse());
+        verify(kakaoPayService, never()).approve(any(), any(), any(), any());
+        verify(realTicketService, never()).createRealTicketFromTempTicket(any());
+    }
+
+    @Test
+    void completePayment_doesNotCreateRealTicketWhenRealTicketAlreadyExists() {
+        TempTicket tempTicket = createTempTicket(ReservationStatus.PENDING);
+
+        when(tempTicketRepository.findWithTicketAndShowById(1L)).thenReturn(Optional.of(tempTicket));
+        when(realTicketRepository.existsByKakaoTid("tid-1")).thenReturn(true);
+
+        KakaoPayResultResponseDTO result = kakaoPayBusinessService.completePayment("1", "pg-token");
+
+        assertEquals(100L, result.getAmateurShowId());
+        assertNull(result.getApproveResponse());
+        verify(kakaoPayService, never()).approve(any(), any(), any(), any());
+        verify(realTicketService, never()).createRealTicketFromTempTicket(any());
+    }
+
+    private TempTicket createTempTicket(ReservationStatus status) {
+        Member member = mock(Member.class);
+        lenient().when(member.getId()).thenReturn(10L);
+
+        AmateurShow show = AmateurShow.builder()
+                .id(100L)
+                .name("show")
+                .detailAddress("address")
+                .build();
+
+        AmateurTicket ticket = AmateurTicket.builder()
+                .amateurShow(show)
+                .discountName("regular")
+                .price(10000)
+                .build();
+
+        AmateurRounds round = AmateurRounds.builder()
+                .amateurShow(show)
+                .performanceDateTime(LocalDateTime.now().plusDays(1))
+                .build();
+
+        return TempTicket.builder()
+                .quantity(1)
+                .reservationStatus(status)
+                .reserveDate(LocalDateTime.now())
+                .performanceDateTime(LocalDateTime.now().plusDays(1))
+                .cancelAvailableUntil(LocalDateTime.now().plusHours(1))
+                .totalPrice(10000)
+                .amateurTicket(ticket)
+                .member(member)
+                .amateurRound(round)
+                .kakaoTid("tid-1")
+                .build();
+    }
+}


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 없음

2. **📝 작업 내용**
    - 카카오페이 결제 승인 로직이 재호출되더라도 동일 결제 건에 대해 `RealTicket`이 중복 생성되지 않도록 방어 로직을 추가했습니다.
    - `KakaoPayBusinessService.completePayment()`에서 `kakaoTid` 기준으로 이미 발행된 `RealTicket`이 있는 경우, 새 티켓을 생성하지 않고 기존 성공 흐름에 필요한 `amateurShowId`를 반환하도록 했습니다.
    - `RealTicketRepository`에 `existsByKakaoTid(String kakaoTid)`를 추가했습니다.
    - 최초 승인, 승인 재호출, 이미 `RealTicket`이 존재하는 케이스에 대한 테스트를 추가했습니다.

    **유지한 것**
    - `TempTicket` / `RealTicket` 구조 재설계 없음
    - DB schema / unique constraint 추가 없음
    - 외부 KakaoPay API 호출 구현 변경 없음
    - approve/cancel/fail redirect 흐름 변경 없음
    - 결제 상태머신 리팩토링 없음

3. **📸 스크린샷 (선택)**
    - 없음

4. **💬 리뷰 요구사항 (선택)**
    - `kakaoTid` 기준으로 중복 `RealTicket` 생성을 방지하는 방식이 현재 결제 승인 흐름에 적절한지 확인 부탁드립니다.
    - 이미 발행된 `RealTicket`이 있는 경우 새로 생성하지 않고 성공 흐름에 필요한 `amateurShowId`를 반환하는 정책이 FE 흐름과 맞는지 검토 부탁드립니다.