### PR TITLE
[DOCS] 백엔드 운영 안정화 점검 계획 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@
 ---
 ## 아키텍쳐
 <img width="1483" height="563" alt="CC 아키텍처 drawio" src="https://github.com/user-attachments/assets/b74fbc11-d0fe-476a-a68c-bb5ee57cf3fe" />
+
+## 운영 문서
+
+- [Dev/Staging Deployment Plan](docs/DEPLOYMENT_PLAN.md)
+- [Backend Operational Audit Plan](docs/BACKEND_OPERATIONAL_AUDIT_PLAN.md): 배포 이후 백엔드 운영 안정화와 데이터 정합성 개선을 위한 후속 PR 분리 기준 문서

--- a/docs/BACKEND_OPERATIONAL_AUDIT_PLAN.md
+++ b/docs/BACKEND_OPERATIONAL_AUDIT_PLAN.md
@@ -36,6 +36,9 @@ Non-goals for this document:
 
 Recommended operating principle:
 
+- Audit externally exposed endpoints before expanding the dev/staging surface with DNS and HTTPS.
+- Establish a repeatable smoke-test baseline before changing DNS, HTTPS, OAuth callback URLs, KakaoPay callback URLs, or frontend API base URLs.
+- Configure dev/staging DNS, HTTPS, and callback URLs after the security and smoke-test baseline exists.
 - Fix low-risk visibility and validation issues first.
 - Analyze real RDS data before adding unique constraints or changing ticket/payment state transitions.
 - Treat payment, ticket stock, refund, and scheduler behavior as high-risk areas that require tests and rollback plans before implementation.
@@ -55,6 +58,10 @@ Recommended operating principle:
 
 | Item | Risk | Recommended branch | Expected files | Verification |
 | --- | --- | --- | --- | --- |
+| Public endpoint exposure audit | The dev/staging server is already externally reachable. `/auth/**`, `/upload/**`, Swagger, Actuator, and KakaoPay callback rules should be audited before adding DNS/HTTPS and making the environment easier to consume. | `security/audit-permit-all-rules` | SecurityConfig audit docs, request matrix, security tests | unauthenticated/authenticated endpoint matrix |
+| Smoke-test baseline before infrastructure changes | DNS/HTTPS changes are hard to validate without a repeatable baseline. Manual curl checks are not enough for later comparisons. | `ops/add-dev-smoke-test-script` | `scripts/smoke-test.sh`, deployment docs | Script passes against current HTTP endpoint and later HTTPS domain |
+| Dev/staging DNS, HTTPS, and callback URL setup | OAuth, KakaoPay redirect, CORS, and frontend API base URL verification are unstable when they rely on a raw EC2 public IP. A real HTTPS dev/staging domain should be configured before full integration testing. | `infra/configure-dev-domain-https` | Nginx HTTPS docs/config, deployment docs, environment reference | `https://<dev-api-domain>/actuator/health`, OAuth redirect check, KakaoPay callback URL check |
+| Dev/staging callback environment update | `FRONTEND_BASE_URL`, `CORS_ALLOWED_ORIGINS`, OAuth redirect URI, and KakaoPay callback URLs must move from IP-based values to domain-based values together. | `chore/update-dev-callback-urls` | EC2 `.env` guide, provider console checklist, deployment docs | HTTPS smoke test, OAuth login test, KakaoPay ready/approve/cancel/fail redirect test |
 | `ddl-auto=update` in dev/prod config | Hibernate can silently mutate schema and hide schema drift. This is risky before production migration. | `chore/introduce-db-migration-baseline` | `application.yml`, `application-prod.yml`, Flyway or Liquibase files | Schema dump comparison, migration from empty DB, migration from staging snapshot |
 | Entity and RDS schema mismatch | JPA annotations do not necessarily match the live RDS schema created by `ddl-auto=update`. | `audit/rds-schema-entity-alignment` | Documentation first, then entity/migration files | RDS schema dump, `SHOW CREATE TABLE`, entity annotation checklist |
 | Admin authorization consistency | Role hierarchy exists, but admin endpoints should be audited for consistent `ADMIN` enforcement and no controller-level gaps. | `fix/admin-authorization-audit` | `admin/**Controller.java`, method security annotations, tests | Unauthorized/performer/audience/admin API tests |
@@ -66,7 +73,7 @@ Recommended operating principle:
 
 | Item | Risk | Recommended branch | Expected files | Verification |
 | --- | --- | --- | --- | --- |
-| SecurityConfig `permitAll` inventory | Current public endpoints should be documented and regression-tested so future changes do not accidentally expose user APIs. | `test/security-permitall-regression` | `SecurityConfig.java` tests only, docs | Spring Security request matcher tests |
+| SecurityConfig `permitAll` regression tests | Current public endpoints should be documented and regression-tested so future changes do not accidentally expose user APIs. | `test/security-permitall-regression` | `SecurityConfig.java` tests only, docs | Spring Security request matcher tests |
 | `/auth/dev/*` profile guard regression | Current controller uses `(local | dev) & !prod`; this should be verified in profile-based tests. | `test/dev-auth-profile-guard` | `DevAuthController` tests, context tests | dev profile registers bean, prod profile does not |
 | Refresh token lifecycle | Redis refresh token save/validate/logout behavior should be tested with expiry and logout flows. | `test/refresh-token-lifecycle` | `TokenProvider.java`, `RefreshTokenService.java`, auth tests | Login, refresh, logout, refresh-after-logout tests |
 | Public actuator health detail | `/actuator/health` is public and `show-details: always`; useful in dev/staging but too verbose for production. | `chore/actuator-prod-hardening` | `application-prod.yml`, deployment docs | Prod profile health response check |
@@ -303,13 +310,19 @@ Do not jump directly into a full rewrite. Recommended sequence:
 - Redis runs inside Docker Compose.
 - Nginx proxies public port 80 to blue/green app ports.
 - Deployment documentation includes smoke test commands.
+- Public endpoint exposure should be audited before adding DNS/HTTPS.
+- A repeatable smoke-test script should exist before DNS/HTTPS changes.
+- DNS, HTTPS, and callback URLs should be configured before full OAuth, KakaoPay, and frontend integration verification, but after the security and smoke-test baseline exists.
 
 ### Recommended Operational Improvements
 
 | Item | Recommended branch | Expected files | Verification |
 | --- | --- | --- | --- |
+| Public endpoint audit | `security/audit-permit-all-rules` | Security docs, request matrix, security tests | unauthenticated/authenticated endpoint matrix |
+| Smoke test script | `ops/add-dev-smoke-test-script` | `scripts/smoke-test.sh`, docs | Script exits non-zero on failed health/API checks |
+| Dev/staging DNS and HTTPS setup | `infra/configure-dev-domain-https` | Nginx HTTPS setup docs/config, deployment docs | HTTPS health, Swagger, public API smoke tests |
+| Callback URL update | `chore/update-dev-callback-urls` | Environment guide, provider console checklist, deployment docs | OAuth redirect and KakaoPay callback tests |
 | CloudWatch log shipping | `chore/cloudwatch-log-agent-dev` | EC2 setup docs, CloudWatch agent config | App, Nginx, Docker logs visible in CloudWatch |
-| Smoke test script | `chore/dev-smoke-test-script` | `scripts/smoke-test.sh`, docs | Script exits non-zero on failed health/API checks |
 | Deployment rollback drill | `docs/rollback-runbook` | Deployment docs | Manual rollback on dev/staging |
 | Actuator production hardening | `chore/actuator-prod-hardening` | `application-prod.yml`, docs | Prod health does not expose unnecessary details |
 | Error log correlation | `chore/request-correlation-id` | filter/interceptor/log config | Request ID appears in app logs |
@@ -331,6 +344,9 @@ docker exec redis redis-cli ping
 
 These are low-risk and can be done without changing business policy:
 
+- Audit and document public endpoint exposure.
+- Add a repeatable smoke test script for the current dev/staging HTTP endpoint.
+- Document dev/staging DNS, HTTPS, and callback URL setup after the baseline exists.
 - Add security/profile regression tests for `/auth/dev/*`.
 - Add SecurityConfig endpoint access tests.
 - Add request DTO validation to clearly required fields.
@@ -343,6 +359,8 @@ These are low-risk and can be done without changing business policy:
 
 These require real schema/data review or a behavior matrix before implementation:
 
+- DNS/HTTPS rollout should wait until public endpoint audit and smoke-test baseline are complete.
+- Full OAuth and KakaoPay integration verification after domain-based HTTPS callback URLs are configured.
 - `RealTicket.kakaoTid` unique constraint.
 - Existing duplicate payment/ticket data cleanup.
 - Entity nullable/index/FK alignment with RDS.
@@ -365,58 +383,85 @@ These should wait until tests and data audit are complete:
 
 ## Recommended Work Order
 
-1. `test/security-permitall-regression`
+1. `security/audit-permit-all-rules`
+   - Purpose: audit externally reachable endpoints before adding DNS/HTTPS or expanding integration traffic.
+   - Files: SecurityConfig audit docs, request matrix, security tests.
+   - Verification: unauthenticated/authenticated endpoint matrix.
+
+2. `ops/add-dev-smoke-test-script`
+   - Purpose: make deployment verification repeatable before infrastructure changes.
+   - Files: `scripts/smoke-test.sh`, deployment docs.
+   - Verification: run against the current HTTP dev/staging endpoint.
+
+3. `infra/configure-dev-domain-https`
+   - Purpose: configure dev/staging DNS and HTTPS after the security and smoke-test baseline exists.
+   - Files: Nginx HTTPS docs/config, deployment docs.
+   - Verification: run the same smoke test against `https://<dev-api-domain>`.
+
+4. `chore/update-dev-callback-urls`
+   - Purpose: move callback and frontend integration URLs from raw IP-based values to domain-based HTTPS values.
+   - Files: EC2 `.env` guide, provider console checklist, deployment docs.
+   - Verification: OAuth redirect check, KakaoPay approve/cancel/fail callback check, CORS check.
+
+5. `test/security-permitall-regression`
    - Purpose: lock down current authentication boundary.
    - Files: Security tests, profile context tests.
    - Verification: unauthenticated/authenticated request matrix.
 
-2. `chore/dev-smoke-test-script`
-   - Purpose: make deployment verification repeatable.
-   - Files: `scripts/smoke-test.sh`, deployment docs.
-   - Verification: run against dev/staging host.
+6. `payment/audit-and-test-ticket-consistency`
+   - Purpose: combine payment/ticket audit with tests so the audit does not become a dead-end document-only task.
+   - Files: audit docs, KakaoPay tests, TempTicket tests, RealTicket tests.
+   - Verification: schema-only checks, duplicate `kakao_tid` SQL, repeated approve tests, concurrent approve tests, cancel/fail/scheduler race tests.
 
-3. `audit/rds-schema-entity-alignment`
-   - Purpose: compare real RDS schema with JPA entities.
-   - Files: audit doc only at first.
-   - Verification: schema-only dump and table/index checklist.
-
-4. `test/payment-ticket-consistency-regression`
-   - Purpose: add tests before risky payment changes.
-   - Files: KakaoPay, TempTicket, RealTicket tests.
-   - Verification: repeated approve, concurrent approve, cancel/fail/scheduler races.
-
-5. `fix/enforce-real-ticket-kakaotid-uniqueness`
+7. `payment/enforce-real-ticket-kakaotid-uniqueness`
    - Purpose: add DB invariant after duplicate data check.
    - Files: migration file, entity/repository tests.
    - Verification: migration dry-run, duplicate insert failure test.
 
-6. `fix/atomic-temp-ticket-expiration-stock-restore`
+8. `payment/atomic-temp-ticket-expiration-stock-restore`
    - Purpose: prevent double stock restore.
    - Files: payment service, scheduler, repository, tests.
    - Verification: concurrent callback/scheduler test.
 
-7. `fix/request-dto-validation-baseline`
+9. `validation/add-ticket-request-validation`
    - Purpose: reduce invalid input and inconsistent 500s.
    - Files: DTOs, controllers, exception tests.
    - Verification: invalid payload test suite.
 
-8. `refactor/kakaopay-transaction-boundaries`
+10. `chore/standardize-api-exception-handling`
+   - Purpose: reduce mixed exception behavior before deeper frontend integration.
+   - Files: exception handler, affected controllers/services, tests.
+   - Verification: representative 400, 401, 403, 404, 409, and 500 response tests.
+
+11. `refactor/kakaopay-transaction-boundaries`
    - Purpose: reduce long transactions and define compensation.
    - Files: payment service structure and tests.
    - Verification: failure simulation around external API and DB save.
 
-9. `chore/introduce-db-migration-baseline`
+12. `frontend/integration-stabilization`
+   - Purpose: stabilize payment button behavior, token refresh, result messages, API base URL, and admin route protection after backend guards and callback URLs are stable.
+   - Files: frontend environment/configuration and route/payment handling files.
+   - Verification: FE login, token refresh, KakaoPay ready, redirect result, and admin route checks.
+
+13. `chore/introduce-db-migration-baseline`
    - Purpose: move away from `ddl-auto=update`.
    - Files: Flyway or Liquibase baseline, application config.
    - Verification: empty DB migration, staging snapshot migration.
 
-10. `chore/actuator-prod-hardening`
+14. `chore/actuator-prod-hardening`
     - Purpose: reduce production operational exposure.
     - Files: prod config, docs.
     - Verification: prod profile health response check.
+
+15. `docs/aws-architecture-improvement-plan`
+    - Purpose: split long-term AWS improvements into smaller tracks instead of treating ECR, OIDC, ALB, ElastiCache, ECS/Fargate, and blue/green redesign as one task.
+    - Files: architecture decision docs.
+    - Verification: documented decision tree and follow-up branch list.
 
 ## Final Notes
 
 - This audit plan intentionally separates documentation, tests, data checks, and risky refactors.
 - Payment and ticket consistency must be protected at both application and database levels.
 - The next most valuable PR is not a refactor; it is a test/audit PR that proves current behavior before changing it.
+- Documentation should be updated inside each follow-up PR instead of being deferred to the end.
+- Long-term AWS architecture work should be split into smaller tracks such as SSH ingress hardening, registry/IAM, ALB/Route 53, ElastiCache, and ECS/Fargate migration.

--- a/docs/BACKEND_OPERATIONAL_AUDIT_PLAN.md
+++ b/docs/BACKEND_OPERATIONAL_AUDIT_PLAN.md
@@ -1,0 +1,336 @@
+# Backend Operational Audit Plan
+
+## Purpose
+
+This document is the follow-up PR separation guide for backend operational stabilization after the dev/staging redeployment.
+
+Use this document to decide:
+
+- Which issues should be fixed immediately.
+- Which issues require real data or schema analysis first.
+- Which issues are risky and should wait until tests, rollback plans, and migration plans are ready.
+- Which branch should own each follow-up task.
+
+This document is intentionally documentation-only. It must not include real secret values, real private keys, passwords, access tokens, or production-only operational credentials.
+
+## Overall Summary
+
+The backend is now deployable to the new AWS dev/staging environment, but production readiness still depends on payment/ticket consistency, database schema governance, authorization regression tests, validation consistency, transaction boundaries, and observability.
+
+The highest-risk area is payment and ticket state consistency. Application-level duplicate RealTicket prevention exists, but DB-level invariants, concurrency behavior, scheduler interaction, and compensation policies still need a deeper audit before production.
+
+Recommended direction:
+
+- Start with tests and audits before risky refactors.
+- Add DB constraints only after checking existing data.
+- Keep payment and ticket changes small, reversible, and covered by concurrency tests.
+- Treat this document as the backlog map for follow-up PRs.
+
+## Critical
+
+| Item | Risk | Recommended branch | Expected files | Verification |
+| --- | --- | --- | --- | --- |
+| RealTicket `kakaoTid` DB uniqueness | Application checks can reduce duplicate issuance, but without a DB unique index, concurrent approve retry risk remains. | `fix/enforce-real-ticket-kakaotid-uniqueness` | `RealTicket.java`, migration files, `RealTicketRepository.java`, KakaoPay tests | Duplicate data SQL, migration dry-run, concurrent approve retry test |
+| Cancel/fail/scheduler stock restore race | Callback and scheduler paths can target the same pending TempTicket. Stock restore must be atomic and idempotent. | `fix/atomic-temp-ticket-expiration-stock-restore` | `KakaoPayBusinessService.java`, `TempTicketExpireScheduler.java`, `TempTicketRepository.java`, concurrency tests | Concurrent cancel/fail/scheduler test, final stock assertion |
+| KakaoPay external calls inside transaction | Long DB transactions around external API calls can create partial failure and lock-duration issues. | `refactor/kakaopay-transaction-boundaries` | `KakaoPayBusinessService.java`, `KakaoPayService.java`, payment tests | Failure simulation, transaction boundary tests, DB state assertions |
+| KakaoPay approve success but DB save failure | If external approval succeeds and local DB persistence fails, manual recovery or compensation policy is required. | `fix/payment-approve-compensation-policy` | `KakaoPayBusinessService.java`, payment recovery docs/tests | Mock DB failure after approve, verify defined recovery behavior |
+
+## High
+
+| Item | Risk | Recommended branch | Expected files | Verification |
+| --- | --- | --- | --- | --- |
+| `ddl-auto=update` risk | Hibernate schema auto-update can hide schema drift and mutate production schema unexpectedly. | `chore/introduce-db-migration-baseline` | `application.yml`, `application-prod.yml`, Flyway or Liquibase migrations | Empty DB migration, staging snapshot migration |
+| RDS schema and entity mismatch | Current live schema may not match entity annotations, nullable rules, indexes, or FK expectations. | `audit/rds-schema-entity-alignment` | Audit doc first, then entity/migration files | `SHOW CREATE TABLE`, schema-only dump, index checklist |
+| Admin authorization consistency | Admin APIs should consistently enforce `ADMIN` role and avoid controller-level gaps. | `fix/admin-authorization-audit` | `admin/**Controller.java`, method security tests | audience/performer/admin request matrix |
+| `@AuthenticationPrincipal` null safety | Controllers often assume authenticated `Member`; SecurityConfig and controller behavior must match. | `fix/auth-principal-null-safety-audit` | Controllers using `@AuthenticationPrincipal`, tests | Unauthenticated request matrix, 401/403 assertions |
+| DTO validation gaps | `@RequestBody` without `@Valid` or DTO constraints can cause inconsistent 400/500 behavior. | `fix/request-dto-validation-baseline` | Request DTOs, controllers, exception tests | Invalid payload tests |
+| Exception handling inconsistency | `GeneralException`, `IllegalArgumentException`, `IllegalStateException`, `ResponseStatusException`, raw `RuntimeException`, and `printStackTrace()` are mixed. | `fix/exception-handling-consistency` | Global exception handler, affected controllers/services | Representative error response tests |
+
+## Medium
+
+| Item | Risk | Recommended branch | Expected files | Verification |
+| --- | --- | --- | --- | --- |
+| SecurityConfig `permitAll` inventory | Public endpoint list should be locked by tests to avoid accidental exposure. | `test/security-permitall-regression` | Security tests | Authenticated/unauthenticated endpoint matrix |
+| `/auth/dev/*` profile guard regression | Dev auth must stay unavailable under `prod`. | `test/dev-auth-profile-guard` | Profile context tests | dev profile registers controller, prod profile does not |
+| Refresh token lifecycle | Redis refresh token save, validate, logout, expiry, and reuse-after-logout behavior needs tests. | `test/refresh-token-lifecycle` | `TokenProvider.java`, `RefreshTokenService.java`, auth tests | login/refresh/logout/refresh-after-logout tests |
+| Actuator health detail | Public health detail is useful in dev/staging, but should be restricted before production. | `chore/actuator-prod-hardening` | `application-prod.yml`, docs | Prod profile health response check |
+| Smoke test automation | Manual deployment checks are easy to skip. | `chore/dev-smoke-test-script` | `scripts/smoke-test.sh`, deployment docs | Script exits non-zero on failed checks |
+| Operational log runbook | App, Docker, Redis, and Nginx log commands should be documented in one place. | `docs/ops-runbook-logs` | Deployment docs/runbook | Manual command verification on EC2 |
+
+## Low
+
+| Item | Risk | Recommended branch | Expected files | Verification |
+| --- | --- | --- | --- | --- |
+| Remove production `printStackTrace()` | Direct stack trace printing is noisy and less searchable than structured logs. | `chore/remove-printstacktrace-production` | Affected production classes | Compile, error path tests |
+| API null/empty response policy | Inconsistent null and empty responses make FE handling harder. | `docs/api-response-policy` | API docs, DTO notes | Contract review |
+| Service responsibility split | Large services are harder to test but refactoring them before behavior tests is risky. | `refactor/service-responsibility-split-plan` | Design doc first | No code verification until implementation PR |
+| Immutable Docker tags | Mutable `latest` tags reduce rollback traceability. | `chore/docker-immutable-image-tags` | GitHub Actions, deploy scripts, docs | Deploy and rollback by commit SHA tag |
+
+## Payment And Ticket Consistency
+
+### Risks
+
+- `RealTicket.kakaoTid` should be reviewed for a unique index.
+- Existing duplicate RealTicket rows must be checked before adding a unique constraint.
+- Approve retry must be idempotent for the same TempTicket/order.
+- Cancel, fail, and scheduler paths must not restore stock more than once.
+- TempTicket status transitions need a documented allowed transition matrix.
+- Payment success followed by local DB failure needs compensation or manual recovery policy.
+
+### Duplicate Data Check SQL
+
+Run against a staging snapshot or read-only operational session. Do not commit query output if it contains user data.
+
+```sql
+SELECT kakao_tid, COUNT(*) AS cnt
+FROM real_ticket
+WHERE kakao_tid IS NOT NULL
+GROUP BY kakao_tid
+HAVING COUNT(*) > 1;
+```
+
+```sql
+SELECT kakao_tid, COUNT(*) AS cnt
+FROM temp_ticket
+WHERE kakao_tid IS NOT NULL
+GROUP BY kakao_tid
+HAVING COUNT(*) > 1;
+```
+
+```sql
+SELECT id, kakao_tid, reservation_status, created_at, updated_at
+FROM temp_ticket
+WHERE kakao_tid IS NOT NULL
+ORDER BY kakao_tid, id;
+```
+
+### Required Tests
+
+- First approve creates exactly one RealTicket.
+- Repeated approve for the same TempTicket does not create a second RealTicket.
+- Concurrent approve for the same TempTicket creates exactly one RealTicket.
+- Cancel callback and fail callback racing against scheduler restore stock once.
+- Approve after TempTicket expiration does not issue a RealTicket.
+- KakaoPay approve succeeds but local DB persistence fails and follows a documented recovery policy.
+
+### State Transition Draft
+
+TempTicket:
+
+```text
+PENDING -> RESERVED
+PENDING -> EXPIRED
+RESERVED -> terminal for TempTicket
+EXPIRED -> terminal
+```
+
+RealTicket:
+
+```text
+RESERVED -> CANCELLED
+RESERVED -> USED
+CANCELLED -> terminal
+USED -> terminal
+```
+
+Do not implement a full state machine until real data, scheduler behavior, and KakaoPay retry behavior are verified.
+
+## DB Level Audit
+
+### Schema Dump
+
+Use schema-only dumps first. Never commit dumps that contain production or user data.
+
+```bash
+mysqldump \
+  --no-data \
+  --single-transaction \
+  --skip-comments \
+  -h <rds-endpoint> \
+  -u <db-user> \
+  -p \
+  <db-name> > schema-only.sql
+```
+
+### SQL Checks
+
+```sql
+SHOW TABLES;
+SHOW CREATE TABLE real_ticket;
+SHOW CREATE TABLE temp_ticket;
+SHOW CREATE TABLE member;
+SHOW CREATE TABLE amateur_rounds;
+SHOW INDEX FROM real_ticket;
+SHOW INDEX FROM temp_ticket;
+SHOW INDEX FROM member;
+```
+
+### Items To Compare
+
+- Entity nullable rules vs actual table nullable rules.
+- Unique constraints and indexes.
+- Foreign keys for member, ticket, amateur round, and show relations.
+- `real_ticket.kakao_tid` uniqueness/index status.
+- `temp_ticket.reservation_status` and `created_at` index for scheduler.
+- Query patterns used by ticket list, admin ticket search, and payment duplicate checks.
+- Current `ddl-auto=update` behavior under dev/prod profiles.
+
+## Authentication And Authorization Audit
+
+### Items To Verify
+
+- `/auth/dev/login` and `/auth/dev/refresh` are not registered under `prod`.
+- SecurityConfig public endpoint list is intentional.
+- `POST /kakaoPay/ready` requires authentication.
+- `GET /kakaoPay/approve`, `/kakaoPay/cancel`, and `/kakaoPay/fail` remain public callback endpoints.
+- Admin APIs consistently require `ADMIN`.
+- Performer and audience permissions are separated.
+- `@AuthenticationPrincipal` usage is null-safe or protected by authentication rules.
+- Redis refresh token lifecycle handles login, refresh, logout, expiry, and refresh-after-logout.
+
+### PermitAll Inventory To Regression-Test
+
+- `OPTIONS /**`
+- `/actuator/health`, `/actuator/info`
+- `/error`
+- `/auth/**`
+- KakaoPay callback endpoints
+- Swagger/OpenAPI docs
+- `/admin/login`
+- Public read APIs for photo albums, boards, amateurs
+- `/upload/**`
+
+## API Validation And Exception Handling
+
+### Validation Search
+
+```bash
+rg -n "@RequestBody" src/main/java
+rg -n "@Valid @RequestBody|@RequestBody .*@Valid" src/main/java
+```
+
+### DTO Constraint Candidates
+
+- `@NotNull` for required IDs, enum values, and date fields.
+- `@NotBlank` for required strings.
+- `@Positive` for quantity, price, page, and size values.
+- `@Size` for user-provided text.
+- `@Valid` for nested DTOs and request lists.
+
+### Exception Policy Direction
+
+- Use `GeneralException` for domain/business errors with known error codes.
+- Use validation exceptions for request validation failures.
+- Avoid raw `RuntimeException` for expected business errors.
+- Replace production `printStackTrace()` with structured logging.
+- Keep API error response shape consistent.
+
+## Transaction And External API Audit
+
+### Questions
+
+- Which service methods call KakaoPay inside an open DB transaction?
+- What DB state remains if KakaoPay approve succeeds but local DB save fails?
+- What DB state remains if KakaoPay cancel succeeds but local ticket cancellation fails?
+- Are stock decrease and TempTicket update atomic?
+- Are stock restore and TempTicket expiration atomic?
+- Can scheduler and callback process the same TempTicket concurrently?
+
+### Recommended Refactor Order
+
+1. Add regression tests for current behavior.
+2. Define payment and ticket state transitions.
+3. Separate external API calls from long transactions where safe.
+4. Add compensation/manual recovery policy.
+5. Consider outbox or payment event table only after the simpler behavior is tested.
+
+## Observability And Operations
+
+### Current Focus
+
+- Actuator health endpoint.
+- Docker Compose app/Redis logs.
+- Nginx access/error logs.
+- Deployment smoke test commands.
+- Rollback and blue/green verification commands.
+
+### Follow-Up Candidates
+
+| Item | Recommended branch | Expected files | Verification |
+| --- | --- | --- | --- |
+| CloudWatch log shipping | `chore/cloudwatch-log-agent-dev` | EC2 setup docs, CloudWatch agent config | App/Nginx/Docker logs visible in CloudWatch |
+| Smoke test script | `chore/dev-smoke-test-script` | `scripts/smoke-test.sh`, docs | Script exits non-zero on failed checks |
+| Rollback runbook | `docs/rollback-runbook` | Deployment docs | Manual rollback drill on dev/staging |
+| Request correlation ID | `chore/request-correlation-id` | filter/interceptor/log config | Request ID appears in app logs |
+
+## Safe To Fix Immediately
+
+- Add security/profile regression tests for `/auth/dev/*`.
+- Add SecurityConfig endpoint access tests.
+- Add request DTO validation for clearly required fields.
+- Replace production `printStackTrace()` with logger usage.
+- Add a dev/staging smoke test script.
+- Expand operational runbook commands.
+- Add refresh token lifecycle tests.
+
+## Analyze Before Fixing
+
+- `RealTicket.kakaoTid` unique constraint.
+- Existing duplicate ticket/payment data cleanup.
+- Entity and RDS schema alignment.
+- `ddl-auto=update` replacement with Flyway or Liquibase.
+- Cancel/fail/scheduler stock restore race.
+- Full admin/performer/audience authorization matrix.
+- API null/empty response policy.
+- Actuator exposure policy by environment.
+
+## Risky To Change Now
+
+- Full payment state machine rewrite.
+- Moving all KakaoPay calls outside transactions without compensation design.
+- Adding unique constraints before duplicate data is checked.
+- Replacing scheduler behavior without concurrency tests.
+- Large service decomposition before regression tests.
+- Production migration tooling rollout without staging rehearsal.
+
+## Recommended Work Order
+
+1. `test/security-permitall-regression`
+   - Purpose: lock down current authentication boundary.
+   - Verification: authenticated/unauthenticated endpoint matrix.
+
+2. `chore/dev-smoke-test-script`
+   - Purpose: make deployment verification repeatable.
+   - Verification: run script against dev/staging host.
+
+3. `audit/rds-schema-entity-alignment`
+   - Purpose: compare live RDS schema with JPA entities.
+   - Verification: schema-only dump and index checklist.
+
+4. `test/payment-ticket-consistency-regression`
+   - Purpose: add tests before risky payment changes.
+   - Verification: repeated approve, concurrent approve, and stock restore race tests.
+
+5. `fix/enforce-real-ticket-kakaotid-uniqueness`
+   - Purpose: add DB invariant after duplicate data check.
+   - Verification: migration dry-run and duplicate insert failure test.
+
+6. `fix/atomic-temp-ticket-expiration-stock-restore`
+   - Purpose: prevent double stock restore.
+   - Verification: concurrent callback/scheduler test.
+
+7. `fix/request-dto-validation-baseline`
+   - Purpose: reduce invalid input and inconsistent 500s.
+   - Verification: invalid payload test suite.
+
+8. `refactor/kakaopay-transaction-boundaries`
+   - Purpose: reduce long transactions and define compensation.
+   - Verification: failure simulation around external API and DB save.
+
+9. `chore/introduce-db-migration-baseline`
+   - Purpose: replace Hibernate schema auto-update with managed migration.
+   - Verification: empty DB migration and staging snapshot migration.
+
+10. `chore/actuator-prod-hardening`
+    - Purpose: reduce production health endpoint exposure.
+    - Verification: prod profile health response check.

--- a/docs/DEPLOYMENT_PLAN.md
+++ b/docs/DEPLOYMENT_PLAN.md
@@ -61,6 +61,7 @@ REDIS_HOST=redis
 
 ## Follow-up Work
 
+- Use [Backend Operational Audit Plan](BACKEND_OPERATIONAL_AUDIT_PLAN.md) as the reference for backend stabilization follow-up PRs.
 - Move Docker registry from Docker Hub to ECR.
 - Use GitHub OIDC instead of long-lived AWS keys.
 - Revisit blue/green deployment after dev/staging is stable.

--- a/docs/DEPLOYMENT_PLAN.md
+++ b/docs/DEPLOYMENT_PLAN.md
@@ -81,6 +81,60 @@ Keep these as follow-up improvements, not part of the first dev/staging stabiliz
 - Run tests in CI instead of `./gradlew build -x test`.
 - Move from Docker Hub secrets to ECR/OIDC later.
 
+## Verification Before Dev Domain And HTTPS
+
+After the first EC2/Nginx health check succeeds, establish the security and smoke-test baseline before changing DNS, HTTPS, OAuth callback URLs, KakaoPay callback URLs, or frontend API base URLs.
+
+This order matters. Without a repeatable smoke test, it is difficult to tell whether a later HTTPS/domain change failed, whether the existing app was already unhealthy, or whether OAuth/KakaoPay callback settings are wrong.
+
+Recommended follow-up branches before domain changes:
+
+- `security/audit-permit-all-rules`
+- `ops/add-dev-smoke-test-script`
+
+The smoke test should accept a base URL so the same checks can run before and after HTTPS:
+
+```bash
+./scripts/smoke-test.sh http://<dev-api-host>
+./scripts/smoke-test.sh https://<dev-api-domain>
+```
+
+## Dev Domain, HTTPS, And Callback URLs
+
+Configure a dev/staging API domain and HTTPS after the public endpoint audit and smoke-test script are in place.
+
+DNS and HTTPS are still required before full OAuth, KakaoPay, and frontend integration verification. Google OAuth, Kakao OAuth, KakaoPay redirect URLs, frontend CORS, and frontend API base URL checks are much more stable when they use a real HTTPS domain instead of a raw EC2 public IP.
+
+Recommended follow-up branches:
+
+- `infra/configure-dev-domain-https`
+- `chore/update-dev-callback-urls`
+- `docs/update-domain-https-deployment-guide`
+
+Items to configure:
+
+- Dev/staging API domain, for example `<dev-api-domain>`.
+- DNS `A` record pointing to the EC2 public IP or Elastic IP.
+- Nginx HTTPS certificate using Certbot or another certificate provider.
+- HTTP `80` to HTTPS `443` redirect.
+- `FRONTEND_BASE_URL`.
+- `CORS_ALLOWED_ORIGINS`.
+- `GOOGLE_REDIRECT_URI`.
+- Kakao OAuth redirect URI.
+- `KAKAOPAY_APPROVE_URL`.
+- `KAKAOPAY_CANCEL_URL`.
+- `KAKAOPAY_FAIL_URL`.
+- Google, Kakao, and KakaoPay console callback/redirect settings.
+
+Smoke test again with the HTTPS domain:
+
+```bash
+curl -i https://<dev-api-domain>/actuator/health
+curl -i https://<dev-api-domain>/swagger-ui/index.html
+curl -i https://<dev-api-domain>/amateurs/ranking
+curl -i -X POST "https://<dev-api-domain>/kakaoPay/ready?tempTicketId=1"
+```
+
 ## Nginx Blue/Green Setup
 
 `switch-blue-green.sh` and `rollback.sh` expect the Nginx upstream entries below in `/etc/nginx/sites-available/default`.
@@ -184,13 +238,19 @@ Expected results:
 4. Configure GitHub Secrets and optional Variables.
 5. Push to `develop` or run the workflow manually.
 6. Verify health with `/actuator/health`.
+7. Audit public endpoints and confirm no obvious dev/staging exposure issue.
+8. Add a repeatable smoke test script and run it against the current HTTP endpoint.
+9. Configure dev/staging DNS, HTTPS, and callback URLs.
+10. Run the same smoke test against the HTTPS domain before full OAuth, KakaoPay, and frontend integration verification.
 
 ## Follow-up Work
 
 - Use [Backend Operational Audit Plan](BACKEND_OPERATIONAL_AUDIT_PLAN.md) as the reference for backend stabilization follow-up PRs.
+- Audit public endpoints and add a repeatable smoke test before DNS/HTTPS changes.
+- Configure dev/staging DNS, HTTPS, and callback URLs after the smoke-test baseline exists.
 - Move Docker registry from Docker Hub to ECR.
 - Use GitHub OIDC instead of long-lived AWS keys.
 - Revisit blue/green deployment after dev/staging is stable.
 - Move runtime secrets to AWS Systems Manager Parameter Store or Secrets Manager.
 - Replace `ddl-auto=update` with a managed migration strategy before production.
-- Add HTTPS/domain routing before production OAuth and KakaoPay verification.
+- Revisit ALB, Route 53 operations, and production HTTPS architecture as a larger AWS architecture improvement.


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - Part of #162

2. **📝 작업 내용**
    - 기존 Notion에서 별도 운영 안정화/정합성 점검 기준 문서를 확인하지 못해, 새 AWS dev/staging 환경 기준의 후속 PR 분리 기준을 문서화했습니다.
    - `docs/BACKEND_OPERATIONAL_AUDIT_PLAN.md`를 추가했습니다.
      - 이 문서는 후속 운영 안정화 작업의 audit plan 및 PR 분리 기준 문서입니다.
    - Critical / High / Medium / Low 우선순위로 점검 항목을 분류했습니다.
      - 결제/티켓 정합성
      - DB 스키마
      - 인증/인가
      - API validation / 예외 처리
      - 트랜잭션 경계
      - 관측성 / 운영
    - 항목별 추천 브랜치명, 예상 변경 파일, 검증 방법, 추천 작업 순서를 정리했습니다.
    - README에 운영 문서 섹션을 추가하고, `DEPLOYMENT_PLAN.md` 및 `BACKEND_OPERATIONAL_AUDIT_PLAN.md` 링크를 연결했습니다.
    - `DEPLOYMENT_PLAN.md`의 Follow-up Work에 Backend Operational Audit Plan을 후속 PR 기준으로 참고하도록 문구를 추가했습니다.

3. **💬 리뷰 요구사항**
    - 기존 Notion에 별도 운영 안정화 기준 문서가 없는 것으로 확인했는데, 제가 놓친 최신 문서가 있다면 공유 부탁드립니다.
    - Critical / High / Medium / Low 우선순위가 현재 dev/staging 운영 리스크와 맞는지 확인 부탁드립니다.
    - 후속 작업 브랜치/PR 분리 기준이 적절한지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operations section to README with links to deployment and operational audit guides.
  * Updated deployment plan with pre-domain verification requirements, including repeatable smoke-test baseline establishment before DNS/HTTPS changes.
  * Expanded operational audit guide with staged audit approach, security endpoint verification, smoke-testing procedures, and detailed work sequencing for infrastructure and callback configuration readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->