### PR TITLE
[OPS] dev/staging 배포 검증 기준 및 공개 엔드포인트 smoke test 추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: gradle
+
+      # 2-1. Gradle 캐시 설정
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       # 3. gradlew 권한 부여
       - name: Make gradlew executable
@@ -35,7 +40,23 @@ jobs:
 
       # 4. Gradle Build (테스트 제외)
       - name: Build with Gradle (skip tests)
-        run: ./gradlew build -x test
+        run: |
+          for i in 1 2 3; do
+            echo "🔨 Gradle build attempt $i/3"
+            if ./gradlew build -x test; then
+              echo "✅ Gradle build completed"
+              exit 0
+            fi
+
+            echo "⚠️ Gradle build failed on attempt $i/3"
+            if [ "$i" -lt 3 ]; then
+              echo "⏳ Retrying in 10 seconds..."
+              sleep 10
+            fi
+          done
+
+          echo "❌ Gradle build failed after 3 attempts"
+          exit 1
 
       # 5. Docker Build & Push
       - name: Build and push Docker image
@@ -43,10 +64,10 @@ jobs:
         run: |
           echo "🔨 Building Docker image..."
           docker build -t ${{ secrets.DOCKER_USERNAME }}/${DOCKER_IMAGE}:${DOCKER_TAG} .
-          
+
           echo "🔐 Logging into Docker Hub..."
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-          
+
           echo "📤 Pushing to Docker Hub..."
           docker push ${{ secrets.DOCKER_USERNAME }}/${DOCKER_IMAGE}:${DOCKER_TAG}
 
@@ -72,16 +93,16 @@ jobs:
           key: ${{ secrets.PRIVATE_KEY }}
           script: |
             cd "${{ env.DEPLOY_PATH }}"
-            
+
             echo "🔒 Docker Hub Login"
             echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-            
+
             echo "📦 Pull latest images"
             export APP_IMAGE="${{ secrets.DOCKER_USERNAME }}/${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}"
             docker compose pull
-            
+
             chmod +x switch-blue-green.sh health-check.sh rollback.sh
-            
+
             echo "🔄 Execute Blue-Green deployment with auto rollback"
             if ./switch-blue-green.sh; then
               echo "✅ Deployment completed successfully"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,33 +30,15 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      # 2-1. Gradle 캐시 설정
+      # 3. Gradle 8.13 설정 및 캐시
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      # 3. gradlew 권한 부여
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
+        with:
+          gradle-version: '8.13'
 
       # 4. Gradle Build (테스트 제외)
       - name: Build with Gradle (skip tests)
-        run: |
-          for i in 1 2 3; do
-            echo "🔨 Gradle build attempt $i/3"
-            if ./gradlew build -x test; then
-              echo "✅ Gradle build completed"
-              exit 0
-            fi
-
-            echo "⚠️ Gradle build failed on attempt $i/3"
-            if [ "$i" -lt 3 ]; then
-              echo "⏳ Retrying in 10 seconds..."
-              sleep 10
-            fi
-          done
-
-          echo "❌ Gradle build failed after 3 attempts"
-          exit 1
+        run: gradle build -x test
 
       # 5. Docker Build & Push
       - name: Build and push Docker image

--- a/docs/DEPLOYMENT_PLAN.md
+++ b/docs/DEPLOYMENT_PLAN.md
@@ -95,9 +95,11 @@ Recommended follow-up branches before domain changes:
 The smoke test should accept a base URL so the same checks can run before and after HTTPS:
 
 ```bash
-./scripts/smoke-test.sh http://<dev-api-host>
-./scripts/smoke-test.sh https://<dev-api-domain>
+./scripts/dev-smoke-test.sh http://<dev-api-host>
+./scripts/dev-smoke-test.sh https://<dev-api-domain>
 ```
+
+The current baseline script is `scripts/dev-smoke-test.sh`. See [Public Endpoint Baseline](PUBLIC_ENDPOINT_BASELINE.md) for the expected public/private endpoint matrix.
 
 ## Dev Domain, HTTPS, And Callback URLs
 
@@ -217,6 +219,18 @@ From a local machine, use the public dev/staging base URL:
 curl -i http://<dev-api-host>/actuator/health
 curl -i http://<dev-api-host>/amateurs/ranking
 curl -i -X POST "http://<dev-api-host>/kakaoPay/ready?tempTicketId=1"
+```
+
+Use the repeatable smoke script for the public/private endpoint baseline:
+
+```bash
+./scripts/dev-smoke-test.sh http://<dev-api-host>
+```
+
+After DNS/HTTPS is configured, run the same checks against the HTTPS domain:
+
+```bash
+./scripts/dev-smoke-test.sh https://<dev-api-domain>
 ```
 
 Expected results:

--- a/docs/PUBLIC_ENDPOINT_BASELINE.md
+++ b/docs/PUBLIC_ENDPOINT_BASELINE.md
@@ -1,0 +1,64 @@
+# Public Endpoint Baseline
+
+This document captures the current dev/staging public exposure baseline before DNS, HTTPS, OAuth callback, KakaoPay callback, or frontend base URL changes.
+
+The goal is not to change security policy in this PR. The goal is to make the current expectation repeatable with `scripts/dev-smoke-test.sh`.
+
+## Current Public/Private Expectations
+
+| Endpoint | Method | Expected anonymous result | Reason |
+| --- | --- | --- | --- |
+| `/actuator/health` | `GET` | `200`, body contains `"status":"UP"` | Public health check for deployment and Nginx/Compose verification. |
+| `/swagger-ui/index.html` | `GET` | `200` | Swagger is currently public in dev/staging. Revisit before production. |
+| `/amateurs/ranking` | `GET` | `200` | Public read API. |
+| `/boards` | `GET` | `400` without `boardType` | Public read API that reaches request validation without authentication. |
+| `/kakaoPay/ready?tempTicketId=1` | `POST` | `401` or `403` | User action. Anonymous requests must be blocked. |
+| `/kakaoPay/approve` | `GET` | `400` without required params | Public KakaoPay callback endpoint. Missing params should fail validation, not authentication. |
+| `/kakaoPay/cancel` | `GET` | `400` without required params | Public KakaoPay callback endpoint. Missing params should fail validation, not authentication. |
+| `/kakaoPay/fail` | `GET` | `400` without required params | Public KakaoPay callback endpoint. Missing params should fail validation, not authentication. |
+| `/myTickets/list` | `GET` | `401` or `403` | User ticket API. Anonymous requests must be blocked. |
+| `/member/myPage` | `GET` | `401` or `403` | User profile API. Anonymous requests must be blocked. |
+| `/admin/dashboard/approval` | `GET` | `401` or `403` | Admin API. Anonymous requests must be blocked. |
+
+## Profile-Sensitive Endpoints
+
+`/auth/dev/login` and `/auth/dev/refresh` are intentionally profile-sensitive.
+
+Current expectation:
+
+- Available only when `local` or `dev` profile is active and `prod` is not active.
+- Not registered when `prod` profile is active.
+- Not included in the smoke script because calling it can mint tokens in dev/staging when seeded test accounts exist.
+
+Follow-up recommendation:
+
+- Add profile-level regression tests in a dedicated security test PR.
+
+## Known Follow-Up Review Items
+
+These are intentionally not changed in this PR:
+
+- `/auth/**` is broadly `permitAll`; controller-level behavior and profile guards need regression tests.
+- Swagger/OpenAPI docs are public in dev/staging; production exposure policy should be revisited.
+- `/actuator/health` exposes details in dev/staging; production exposure policy should be revisited.
+- `/upload/**` is currently public in `SecurityConfig`; confirm whether this path is only a generated object path or an application endpoint that can mutate state.
+
+## Smoke Test Usage
+
+Run against the current HTTP endpoint:
+
+```bash
+./scripts/dev-smoke-test.sh http://<dev-api-host>
+```
+
+After DNS/HTTPS is configured, run the same script against the HTTPS domain:
+
+```bash
+./scripts/dev-smoke-test.sh https://<dev-api-domain>
+```
+
+Optional timeout override:
+
+```bash
+SMOKE_TIMEOUT_SECONDS=20 ./scripts/dev-smoke-test.sh http://<dev-api-host>
+```

--- a/scripts/dev-smoke-test.sh
+++ b/scripts/dev-smoke-test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-}"
+if [[ -z "$BASE_URL" ]]; then
+  echo "Usage: $0 <base-url>" >&2
+  echo "Example: $0 http://52.79.122.153" >&2
+  echo "Example: $0 https://api-dev.example.com" >&2
+  exit 2
+fi
+
+BASE_URL="${BASE_URL%/}"
+TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-10}"
+FAILED=0
+
+request_status() {
+  local method="$1"
+  local path="$2"
+  local body_file="$3"
+
+  if [[ -n "$body_file" ]]; then
+    curl -sS -o "$body_file" -w "%{http_code}" \
+      --connect-timeout "$TIMEOUT_SECONDS" \
+      --max-time "$TIMEOUT_SECONDS" \
+      -X "$method" \
+      "$BASE_URL$path"
+  else
+    curl -sS -o /dev/null -w "%{http_code}" \
+      --connect-timeout "$TIMEOUT_SECONDS" \
+      --max-time "$TIMEOUT_SECONDS" \
+      -X "$method" \
+      "$BASE_URL$path"
+  fi
+}
+
+expect_status() {
+  local name="$1"
+  local method="$2"
+  local path="$3"
+  local expected_regex="$4"
+  local status
+
+  set +e
+  status="$(request_status "$method" "$path" "")"
+  local curl_exit=$?
+  set -e
+
+  if [[ $curl_exit -ne 0 ]]; then
+    echo "FAIL $name: curl exit=$curl_exit path=$method $path"
+    FAILED=1
+    return
+  fi
+
+  if [[ "$status" =~ ^($expected_regex)$ ]]; then
+    echo "PASS $name: $status $method $path"
+  else
+    echo "FAIL $name: expected $expected_regex, got $status for $method $path"
+    FAILED=1
+  fi
+}
+
+expect_health_up() {
+  local body
+  body="$(mktemp)"
+
+  set +e
+  local status
+  status="$(request_status "GET" "/actuator/health" "$body")"
+  local curl_exit=$?
+  set -e
+
+  if [[ $curl_exit -ne 0 ]]; then
+    echo "FAIL actuator health: curl exit=$curl_exit"
+    FAILED=1
+  elif [[ "$status" != "200" ]]; then
+    echo "FAIL actuator health: expected 200, got $status"
+    FAILED=1
+  elif ! grep -q '"status":"UP"' "$body"; then
+    echo "FAIL actuator health: response does not contain status UP"
+    FAILED=1
+  else
+    echo "PASS actuator health: 200 and status UP"
+  fi
+
+  rm -f "$body"
+}
+
+echo "Running dev/staging smoke test against $BASE_URL"
+
+# Public operational/read endpoints.
+expect_health_up
+expect_status "swagger ui is reachable" "GET" "/swagger-ui/index.html" "200"
+expect_status "public ranking API is reachable" "GET" "/amateurs/ranking" "200"
+expect_status "public boards API reaches validation" "GET" "/boards" "400"
+
+# KakaoPay boundary: ready is a user action, callbacks are public redirects.
+expect_status "kakaoPay ready blocks anonymous user" "POST" "/kakaoPay/ready?tempTicketId=1" "401|403"
+expect_status "kakaoPay approve callback is public and reaches validation" "GET" "/kakaoPay/approve" "400"
+expect_status "kakaoPay cancel callback is public and reaches validation" "GET" "/kakaoPay/cancel" "400"
+expect_status "kakaoPay fail callback is public and reaches validation" "GET" "/kakaoPay/fail" "400"
+
+# Private user/admin endpoints should reject anonymous requests.
+expect_status "my tickets requires authentication" "GET" "/myTickets/list" "401|403"
+expect_status "member myPage requires authentication" "GET" "/member/myPage" "401|403"
+expect_status "admin dashboard requires authentication" "GET" "/admin/dashboard/approval" "401|403"
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "Smoke test failed for $BASE_URL"
+  exit 1
+fi
+
+echo "Smoke test passed for $BASE_URL"

--- a/scripts/dev-smoke-test.sh
+++ b/scripts/dev-smoke-test.sh
@@ -75,7 +75,7 @@ expect_health_up() {
   elif [[ "$status" != "200" ]]; then
     echo "FAIL actuator health: expected 200, got $status"
     FAILED=1
-  elif ! grep -q '"status":"UP"' "$body"; then
+  elif ! grep -Eq '"status"[[:space:]]*:[[:space:]]*"UP"' "$body"; then
     echo "FAIL actuator health: response does not contain status UP"
     FAILED=1
   else

--- a/src/test/java/cc/backend/config/jwt/SecurityConfigPublicEndpointBaselineTest.java
+++ b/src/test/java/cc/backend/config/jwt/SecurityConfigPublicEndpointBaselineTest.java
@@ -1,0 +1,30 @@
+package cc.backend.config.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class SecurityConfigPublicEndpointBaselineTest {
+
+    private static final Path SECURITY_CONFIG = Path.of(
+            "src/main/java/cc/backend/config/jwt/SecurityConfig.java"
+    );
+
+    @Test
+    void publicAndPrivateEndpointBoundariesRemainExplicit() throws IOException {
+        String source = Files.readString(SECURITY_CONFIG);
+
+        assertThat(source).contains(".requestMatchers(\"/actuator/health\").permitAll()");
+        assertThat(source).contains(".requestMatchers(\"/auth/**\").permitAll()");
+        assertThat(source).contains(".requestMatchers(HttpMethod.GET, \"/kakaoPay/approve\", \"/kakaoPay/cancel\", \"/kakaoPay/fail\").permitAll()");
+        assertThat(source).contains(".requestMatchers(HttpMethod.POST, \"/kakaoPay/ready\").authenticated()");
+        assertThat(source).contains(".requestMatchers(\"/swagger-ui/**\").permitAll()");
+        assertThat(source).contains(".requestMatchers(\"/admin/login\").permitAll()");
+        assertThat(source).contains(".requestMatchers(HttpMethod.GET, \"/amateurs/ranking\").permitAll()");
+        assertThat(source).contains(".requestMatchers(\"/upload/**\").permitAll()");
+        assertThat(source).contains(".anyRequest().authenticated()");
+    }
+}

--- a/src/test/java/cc/backend/config/jwt/SecurityConfigPublicEndpointBaselineTest.java
+++ b/src/test/java/cc/backend/config/jwt/SecurityConfigPublicEndpointBaselineTest.java
@@ -1,30 +1,139 @@
 package cc.backend.config.jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@WebMvcTest(controllers = SecurityConfigPublicEndpointBaselineTest.BaselineController.class)
+@Import({SecurityConfig.class, SecurityConfigPublicEndpointBaselineTest.TestSecurityBeans.class})
+@TestPropertySource(properties = "cors.allowed-origins=http://localhost:*")
 class SecurityConfigPublicEndpointBaselineTest {
 
-    private static final Path SECURITY_CONFIG = Path.of(
-            "src/main/java/cc/backend/config/jwt/SecurityConfig.java"
-    );
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @Test
-    void publicAndPrivateEndpointBoundariesRemainExplicit() throws IOException {
-        String source = Files.readString(SECURITY_CONFIG);
+    @WithAnonymousUser
+    void publicEndpointsAreNotBlockedByAuthentication() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(notAuthBlocked());
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(notAuthBlocked());
+        mockMvc.perform(get("/kakaoPay/approve"))
+                .andExpect(notAuthBlocked());
+        mockMvc.perform(get("/kakaoPay/cancel"))
+                .andExpect(notAuthBlocked());
+        mockMvc.perform(get("/kakaoPay/fail"))
+                .andExpect(notAuthBlocked());
+    }
 
-        assertThat(source).contains(".requestMatchers(\"/actuator/health\").permitAll()");
-        assertThat(source).contains(".requestMatchers(\"/auth/**\").permitAll()");
-        assertThat(source).contains(".requestMatchers(HttpMethod.GET, \"/kakaoPay/approve\", \"/kakaoPay/cancel\", \"/kakaoPay/fail\").permitAll()");
-        assertThat(source).contains(".requestMatchers(HttpMethod.POST, \"/kakaoPay/ready\").authenticated()");
-        assertThat(source).contains(".requestMatchers(\"/swagger-ui/**\").permitAll()");
-        assertThat(source).contains(".requestMatchers(\"/admin/login\").permitAll()");
-        assertThat(source).contains(".requestMatchers(HttpMethod.GET, \"/amateurs/ranking\").permitAll()");
-        assertThat(source).contains(".requestMatchers(\"/upload/**\").permitAll()");
-        assertThat(source).contains(".anyRequest().authenticated()");
+    @Test
+    @WithAnonymousUser
+    void privateEndpointsBlockAnonymousRequests() throws Exception {
+        mockMvc.perform(post("/kakaoPay/ready?tempTicketId=1"))
+                .andExpect(authBlocked());
+        mockMvc.perform(get("/myTickets/list"))
+                .andExpect(authBlocked());
+        mockMvc.perform(get("/member/myPage"))
+                .andExpect(authBlocked());
+        mockMvc.perform(get("/admin/dashboard/approval"))
+                .andExpect(authBlocked());
+    }
+
+    private static ResultMatcher notAuthBlocked() {
+        return result -> assertThat(result.getResponse().getStatus())
+                .isNotIn(HttpServletResponse.SC_UNAUTHORIZED, HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    private static ResultMatcher authBlocked() {
+        return result -> assertThat(result.getResponse().getStatus())
+                .isIn(HttpServletResponse.SC_UNAUTHORIZED, HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    @RestController
+    static class BaselineController {
+
+        @GetMapping({
+                "/actuator/health",
+                "/v3/api-docs",
+                "/kakaoPay/approve",
+                "/kakaoPay/cancel",
+                "/kakaoPay/fail"
+        })
+        String publicEndpoint() {
+            return "ok";
+        }
+
+        @PostMapping("/kakaoPay/ready")
+        String kakaoPayReady() {
+            return "ok";
+        }
+
+        @GetMapping({
+                "/myTickets/list",
+                "/member/myPage",
+                "/admin/dashboard/approval"
+        })
+        String privateEndpoint() {
+            return "ok";
+        }
+    }
+
+    @TestConfiguration
+    static class TestSecurityBeans {
+
+        @Bean
+        TokenProvider tokenProvider() {
+            return mock(TokenProvider.class);
+        }
+
+        @Bean
+        JwtFilter jwtFilter(TokenProvider tokenProvider) {
+            return new PassThroughJwtFilter(tokenProvider);
+        }
+    }
+
+    private static class PassThroughJwtFilter extends JwtFilter {
+
+        PassThroughJwtFilter(TokenProvider tokenProvider) {
+            super(tokenProvider);
+        }
+
+        @Override
+        protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws ServletException, IOException {
+            if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            filterChain.doFilter(request, response);
+        }
     }
 }


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - Part of #162 

## 2. 📝 작업 내용
신규 AWS dev/staging 배포 환경에서 public/private endpoint 노출 상태를 반복 검증할 수 있도록 smoke test 기준을 추가했습니다.
주요 작업 내용은 다음과 같습니다.
- `scripts/dev-smoke-test.sh` 추가
  - base URL을 인자로 받아 HTTP IP 환경과 HTTPS 도메인 환경 모두에서 실행 가능
  - health, Swagger, public API, KakaoPay callback, private API 인증 차단 여부 검증
- public/private endpoint baseline 문서화
  - 공개되어야 하는 endpoint와 인증 없이 차단되어야 하는 endpoint의 기대 상태 정리
  - KakaoPay `ready`는 비인증 요청 차단 대상으로 확인
  - KakaoPay `approve/cancel/fail`은 callback 성격으로 public 유지
- dev/staging 도메인/HTTPS 검증 완료
  - `api.seeatheater.store` 기준 HTTPS health check 통과
  - Route 53 DNS, Nginx, Certbot 기반 HTTPS 적용 후 동일 smoke test 재실행
  - HTTPS 도메인 환경에서도 public/private endpoint 기대 상태 확인
- `DEPLOYMENT_PLAN.md` 업데이트
  - smoke test 실행법 추가
  - DNS/HTTPS 적용 전후 동일 스크립트로 검증하는 흐름 정리
  - 후속 OAuth/KakaoPay 설정 정리 항목 추가

### Smoke Test Result
실행 명령어: `./scripts/dev-smoke-test.sh https://api.seeatheater.store`
결과:
<img width="1280" height="386" alt="Smoke test result" src="https://github.com/user-attachments/assets/724c822d-9aef-4aef-b570-17443d18149c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment plan with clear, repeatable endpoint validation procedures for staging and production environments
  * Introduced new baseline documentation defining public endpoint security expectations and configuration details

* **Tests**
  * Added test verification to ensure proper security configuration for authenticated and public endpoint access patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->