### PR TITLE
[FIX] 결제/예매 정합성 baseline 보강

### DIFF
--- a/docs/PAYMENT_CONSISTENCY_BASELINE.md
+++ b/docs/PAYMENT_CONSISTENCY_BASELINE.md
@@ -1,0 +1,51 @@
+# Payment Consistency Baseline
+
+This document records the narrow payment consistency safeguards added for the
+dev/staging baseline. It intentionally does not introduce database schema
+changes, migrations, or large transaction-boundary refactors.
+
+## Scope
+
+The current ticketing flow creates a `TempTicket` in `PENDING` status first.
+KakaoPay `ready` then preempts stock by decreasing `amateur_rounds.total_ticket`
+and stores the returned KakaoPay `tid` in `temp_ticket.kakao_tid`. KakaoPay
+`approve` confirms the reservation and creates a `RealTicket`.
+
+This baseline only blocks clear invalid requests and duplicate ready calls that
+can safely be handled without changing the broader payment state machine.
+
+## Fixed In This Baseline
+
+- Reject `TempTicket` creation when `quantity <= 0`.
+- Reject duplicate `/kakaoPay/ready` calls when the target `TempTicket` already
+  has a `kakaoTid`.
+- Ensure duplicate ready calls are rejected before stock is decreased.
+
+## Deferred Follow-Ups
+
+- Make `stopPayment` state transitions atomic.
+- Prevent `cancel`, `fail`, and scheduler races from restoring stock more than
+  once.
+- Add a database-level unique constraint for `real_ticket.kakao_tid` after
+  auditing existing duplicate data.
+- Separate KakaoPay external API calls from long-running database transactions.
+- Make `cancelTicket` idempotent and safe against concurrent duplicate cancel
+  requests.
+- Expand payment state transition tests for approve, cancel, fail, scheduler,
+  and database-save failure scenarios.
+
+## Verification
+
+Run the focused tests:
+
+```bash
+./gradlew test --tests cc.backend.kakaoPay.service.KakaoPayBusinessServiceTest --no-daemon
+./gradlew test --tests cc.backend.ticket.service.TempTicketServiceImplTest --no-daemon
+```
+
+Run compile and whitespace checks:
+
+```bash
+./gradlew compileJava --no-daemon
+git diff --check
+```

--- a/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
+++ b/src/main/java/cc/backend/kakaoPay/service/KakaoPayBusinessService.java
@@ -45,6 +45,10 @@ public class KakaoPayBusinessService {
             throw new GeneralException(ErrorStatus.NOT_TEMP_TICKET_OWNER);
         }
 
+        if (tempTicket.getKakaoTid() != null) {
+            throw new GeneralException(ErrorStatus.TEMP_TICKET_STATUS_INVALID);
+        }
+
         // 재고 선점
         preemptStock(tempTicket);
 

--- a/src/main/java/cc/backend/ticket/service/TempTicketServiceImpl.java
+++ b/src/main/java/cc/backend/ticket/service/TempTicketServiceImpl.java
@@ -45,6 +45,10 @@ public class TempTicketServiceImpl implements TempTicketService {
     @Transactional
     public TempTicketCreateResponseDTO createTempTicket(Long amateurShowId, Long amateurRoundId, Long amateurTicketId, Member member, TempTicketCreateRequestDTO requestDTO) {
 
+        if (requestDTO.getQuantity() <= 0) {
+            throw new GeneralException(ErrorStatus.TEMP_TICKET_QUANTITY);
+        }
+
         Member memberRef = memberRepository.getReferenceById(member.getId());
         AmateurShow show = amateurShowRepository.findById(amateurShowId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));

--- a/src/test/java/cc/backend/kakaoPay/service/KakaoPayBusinessServiceTest.java
+++ b/src/test/java/cc/backend/kakaoPay/service/KakaoPayBusinessServiceTest.java
@@ -4,6 +4,8 @@ import cc.backend.amateurShow.entity.AmateurRounds;
 import cc.backend.amateurShow.entity.AmateurShow;
 import cc.backend.amateurShow.entity.AmateurTicket;
 import cc.backend.amateurShow.repository.AmateurRoundsRepository;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
 import cc.backend.kakaoPay.dto.responseDTO.KakaoPayApproveResponseDTO;
 import cc.backend.kakaoPay.dto.responseDTO.KakaoPayResultResponseDTO;
 import cc.backend.member.entity.Member;
@@ -23,6 +25,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -96,6 +100,20 @@ class KakaoPayBusinessServiceTest {
         assertNull(result.getApproveResponse());
         verify(kakaoPayService, never()).approve(any(), any(), any(), any());
         verify(realTicketService, never()).createRealTicketFromTempTicket(any());
+    }
+
+    @Test
+    void preparePayment_throwsWhenKakaoTidAlreadyExists() {
+        TempTicket tempTicket = createTempTicket(ReservationStatus.PENDING);
+
+        when(tempTicketRepository.findWithTicketAndShowById(1L)).thenReturn(Optional.of(tempTicket));
+
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> kakaoPayBusinessService.preparePayment(1L, "10"));
+
+        assertSame(ErrorStatus.TEMP_TICKET_STATUS_INVALID, exception.getCode());
+        verify(amateurRoundsRepository, never()).decreaseStock(anyLong(), anyInt());
+        verify(kakaoPayService, never()).ready(anyLong(), anyString());
     }
 
     private TempTicket createTempTicket(ReservationStatus status) {

--- a/src/test/java/cc/backend/ticket/service/TempTicketServiceImplTest.java
+++ b/src/test/java/cc/backend/ticket/service/TempTicketServiceImplTest.java
@@ -1,0 +1,78 @@
+package cc.backend.ticket.service;
+
+import cc.backend.amateurShow.repository.AmateurRoundsRepository;
+import cc.backend.amateurShow.repository.AmateurShowRepository;
+import cc.backend.amateurShow.repository.AmateurTicketRepository;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.member.entity.Member;
+import cc.backend.member.repository.MemberRepository;
+import cc.backend.ticket.dto.request.TempTicketCreateRequestDTO;
+import cc.backend.ticket.repository.TempTicketRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class TempTicketServiceImplTest {
+
+    @Mock
+    private TempTicketRepository tempTicketRepository;
+
+    @Mock
+    private AmateurShowRepository amateurShowRepository;
+
+    @Mock
+    private AmateurTicketRepository amateurTicketRepository;
+
+    @Mock
+    private AmateurRoundsRepository amateurRoundsRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private RealTicketService realTicketService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private TempTicketServiceImpl tempTicketService;
+
+    @Test
+    void createTempTicket_throwsWhenQuantityIsZero() {
+        TempTicketCreateRequestDTO request = TempTicketCreateRequestDTO.builder()
+                .quantity(0)
+                .build();
+
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> tempTicketService.createTempTicket(1L, 1L, 1L, mock(Member.class), request));
+
+        assertSame(ErrorStatus.TEMP_TICKET_QUANTITY, exception.getCode());
+        verifyNoInteractions(memberRepository, amateurShowRepository, amateurRoundsRepository,
+                amateurTicketRepository, tempTicketRepository, eventPublisher);
+    }
+
+    @Test
+    void createTempTicket_throwsWhenQuantityIsNegative() {
+        TempTicketCreateRequestDTO request = TempTicketCreateRequestDTO.builder()
+                .quantity(-1)
+                .build();
+
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> tempTicketService.createTempTicket(1L, 1L, 1L, mock(Member.class), request));
+
+        assertSame(ErrorStatus.TEMP_TICKET_QUANTITY, exception.getCode());
+        verifyNoInteractions(memberRepository, amateurShowRepository, amateurRoundsRepository,
+                amateurTicketRepository, tempTicketRepository, eventPublisher);
+    }
+}


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - Part of #162

2. **📝 작업 내용**

결제/예매 흐름에서 현재 안전하게 보강 가능한 정합성 문제를 최소 범위로 수정했습니다.

- 예매 생성 시 `quantity <= 0` 요청을 차단했습니다.
  - 기존에는 `quantity > totalTicket`만 검사해 0 또는 음수 quantity가 들어올 수 있는 여지가 있었습니다.
  - 기존 `TEMP_TICKET_QUANTITY` 에러를 재사용했습니다.

- `/kakaoPay/ready` 중복 호출을 방어했습니다.
  - 이미 `kakaoTid`가 저장된 `TempTicket`에 대해 ready가 재호출되면 재고가 중복 차감될 수 있어, 재고 차감 전에 차단하도록 했습니다.
  - 기존 `TEMP_TICKET_STATUS_INVALID` 에러를 재사용했습니다.

- 관련 테스트를 추가/보강했습니다.
  - `quantity=0` 예매 요청 차단
  - `quantity=-1` 예매 요청 차단
  - invalid quantity일 때 repository/event 호출 없음 검증
  - `kakaoTid`가 이미 있는 TempTicket의 ready 재호출 차단
  - ready 재호출 시 `decreaseStock` 미호출 검증
  - 기존 completePayment 중복 RealTicket 방지 테스트 유지

- `PAYMENT_CONSISTENCY_BASELINE.md`를 추가해 이번 PR에서 해결한 항목과 후속으로 분리할 항목을 정리했습니다.

3. **💬 리뷰 요구사항**
- `quantity <= 0`을 기존 `TEMP_TICKET_QUANTITY` 에러로 차단하는 방식이 적절한지 확인 부탁드립니다.
- 이미 `kakaoTid`가 저장된 TempTicket의 `/kakaoPay/ready` 재호출을 `TEMP_TICKET_STATUS_INVALID`로 차단하는 기준이 현재 결제 흐름과 맞는지 검토 부탁드립니다.
- `stopPayment`, scheduler 경합, DB unique constraint, transaction boundary는 후속 PR로 분리하는 판단이 적절한지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added payment consistency baseline reference guide

* **Bug Fixes**
  * Fixed acceptance of zero or negative ticket quantities
  * Fixed acceptance of duplicate payment ready requests for already-processed tickets
  * Strengthened payment validation to prevent invalid state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->