### PR TITLE
[FIX] RealTicket kakaoTid unique constraint 추가

### DIFF
--- a/docs/PAYMENT_DB_CONSTRAINT.md
+++ b/docs/PAYMENT_DB_CONSTRAINT.md
@@ -1,0 +1,100 @@
+# Payment DB Constraint
+
+This document records the database invariant for preventing duplicate
+`RealTicket` rows for the same KakaoPay transaction id.
+
+## Purpose
+
+`KakaoPayBusinessService.completePayment()` already checks
+`RealTicketRepository.existsByKakaoTid(kakaoTid)` before issuing a
+`RealTicket`. That application-level guard handles normal retries, but it cannot
+fully prevent race conditions when duplicate approve callbacks are processed at
+the same time.
+
+The database must enforce the final invariant:
+
+- one non-null `real_ticket.kakao_tid` can map to at most one `RealTicket`
+
+`kakao_tid` remains nullable in this PR because older or non-payment-created
+rows may exist. MySQL unique indexes allow multiple `NULL` values.
+
+## Pre-Apply Checks
+
+Run these checks before applying the unique constraint in any environment:
+
+```sql
+SHOW CREATE TABLE real_ticket;
+
+SHOW INDEX FROM real_ticket;
+
+SELECT COUNT(*) AS total_real_ticket_count
+FROM real_ticket;
+
+SELECT COUNT(*) AS null_kakao_tid_count
+FROM real_ticket
+WHERE kakao_tid IS NULL;
+
+SELECT kakao_tid, COUNT(*) AS cnt
+FROM real_ticket
+WHERE kakao_tid IS NOT NULL
+GROUP BY kakao_tid
+HAVING COUNT(*) > 1;
+```
+
+The duplicate check must return no rows before applying the constraint.
+
+## Apply SQL
+
+```sql
+ALTER TABLE real_ticket
+ADD CONSTRAINT uk_real_ticket_kakao_tid UNIQUE (kakao_tid);
+```
+
+Equivalent form:
+
+```sql
+CREATE UNIQUE INDEX uk_real_ticket_kakao_tid
+ON real_ticket (kakao_tid);
+```
+
+Use only one of the two statements.
+
+## Rollback SQL
+
+```sql
+ALTER TABLE real_ticket
+DROP INDEX uk_real_ticket_kakao_tid;
+```
+
+## Verification SQL
+
+```sql
+SHOW INDEX FROM real_ticket
+WHERE Key_name = 'uk_real_ticket_kakao_tid';
+
+SELECT kakao_tid, COUNT(*) AS cnt
+FROM real_ticket
+WHERE kakao_tid IS NOT NULL
+GROUP BY kakao_tid
+HAVING COUNT(*) > 1;
+```
+
+## Application Behavior
+
+After this constraint is applied, concurrent duplicate inserts for the same
+`kakao_tid` will fail at the database level. The current application-level
+`existsByKakaoTid` check should still remain because it avoids unnecessary
+duplicate work for ordinary retries.
+
+If duplicate approve races still surface as user-visible errors, add a follow-up
+application fallback that catches duplicate key violations, re-queries the
+existing `RealTicket` by `kakaoTid`, and treats the callback as an idempotent
+success when the existing row is found.
+
+## Out Of Scope
+
+- `stopPayment` atomic state transition refactor
+- cancel, fail, and scheduler race handling
+- KakaoPay external API transaction-boundary redesign
+- Flyway or Liquibase introduction
+- production schema change execution

--- a/src/main/java/cc/backend/ticket/entity/RealTicket.java
+++ b/src/main/java/cc/backend/ticket/entity/RealTicket.java
@@ -18,6 +18,10 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_real_ticket_kakao_tid",
+        columnNames = "kakao_tid"
+))
 public class RealTicket extends BaseEntity {
 
     @Id

--- a/src/test/java/cc/backend/ticket/entity/RealTicketConstraintTest.java
+++ b/src/test/java/cc/backend/ticket/entity/RealTicketConstraintTest.java
@@ -1,0 +1,25 @@
+package cc.backend.ticket.entity;
+
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RealTicketConstraintTest {
+
+    @Test
+    void realTicketDeclaresUniqueConstraintOnKakaoTid() {
+        Table table = RealTicket.class.getAnnotation(Table.class);
+
+        assertTrue(Arrays.stream(table.uniqueConstraints())
+                .anyMatch(RealTicketConstraintTest::isKakaoTidUniqueConstraint));
+    }
+
+    private static boolean isKakaoTidUniqueConstraint(UniqueConstraint constraint) {
+        return "uk_real_ticket_kakao_tid".equals(constraint.name())
+                && Arrays.asList(constraint.columnNames()).contains("kakao_tid");
+    }
+}


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - Part of #162

2. **📝 작업 내용**
    - `real_ticket.kakao_tid`에 unique constraint를 추가했습니다.
    - 목적은 KakaoPay approve 동시성 상황에서 같은 `kakaoTid`로 `RealTicket`이 중복 생성되는 것을 DB 레벨에서 방어하는 것입니다.
    - `RealTicket` 엔티티에 `uk_real_ticket_kakao_tid` unique constraint 선언을 추가했습니다.
    - 적용 전/후 확인 SQL, 적용 SQL, rollback SQL을 `PAYMENT_DB_CONSTRAINT.md`에 정리했습니다.
    - `RealTicketConstraintTest`를 추가해 constraint 선언 여부를 검증했습니다.
    - dev/staging RDS에도 실제 unique index를 수동 적용하고 확인했습니다.

    **RDS 적용 결과**
    - 적용 전 `real_ticket` 전체 건수: 4
    - `kakao_tid IS NULL`: 0
    - `kakao_tid` 중복: 없음
    - 적용 SQL:
      ```sql
      ALTER TABLE real_ticket
      ADD CONSTRAINT uk_real_ticket_kakao_tid UNIQUE (kakao_tid);
      ```
    - 적용 후 `SHOW INDEX FROM real_ticket`에서 `uk_real_ticket_kakao_tid`, `Non_unique=0` 확인

3. **💬 리뷰 요구사항**
    - `kakaoTid` unique constraint 방식이 현재 결제 중복 방어 흐름과 맞는지 확인 부탁드립니다.
    - `kakao_tid` nullable 여부는 이번 PR에서 변경하지 않았는데, 추후 `NOT NULL`까지 검토할 필요가 있을지 의견 부탁드립니다.