### PR TITLE
[FIX] 티켓/결제 validation 및 error baseline 보강

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,11 +36,15 @@ jobs:
         with:
           gradle-version: '8.13'
 
-      # 4. Gradle Build (테스트 제외)
-      - name: Build with Gradle (skip tests)
-        run: gradle build -x test
+      # 4. gradlew 권한 부여
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
 
-      # 5. Docker Build & Push
+      # 5. Gradle Build (테스트 제외)
+      - name: Build with Gradle (skip tests)
+        run: ./gradlew build -x test
+
+      # 6. Docker Build & Push
       - name: Build and push Docker image
         if: github.event_name != 'pull_request'
         run: |
@@ -53,7 +57,7 @@ jobs:
           echo "📤 Pushing to Docker Hub..."
           docker push ${{ secrets.DOCKER_USERNAME }}/${DOCKER_IMAGE}:${DOCKER_TAG}
 
-      # 6. 배포 파일들을 EC2로 복사
+      # 7. 배포 파일들을 EC2로 복사
       - name: Copy deployment files to EC2
         if: github.event_name != 'pull_request'
         uses: appleboy/scp-action@v0.1.7
@@ -65,7 +69,7 @@ jobs:
           target: ${{ env.DEPLOY_PATH }}
           overwrite: true
 
-      # 7. EC2에서 블루그린 배포 실행
+      # 8. EC2에서 블루그린 배포 실행
       - name: Deploy with Blue-Green strategy
         if: github.event_name != 'pull_request'
         uses: appleboy/ssh-action@v0.1.10

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,14 +28,17 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: gradle
 
-      # 3. gradlew 권한 부여
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
+      # 3. Gradle 8.13 설정 및 캐시
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
 
       # 4. Gradle Build (테스트 제외)
       - name: Build with Gradle (skip tests)
-        run: ./gradlew build -x test
+        run: gradle build -x test
 
       # 5. Docker Build & Push
       - name: Build and push Docker image

--- a/docs/TICKET_PAYMENT_VALIDATION_BASELINE.md
+++ b/docs/TICKET_PAYMENT_VALIDATION_BASELINE.md
@@ -1,0 +1,61 @@
+# Ticket / Payment Validation Baseline
+
+This document records the minimal validation and error-handling baseline for the
+ticket reservation and KakaoPay request flow. It is intentionally narrow: it
+does not change payment state transitions, transaction boundaries, database
+schema, or external KakaoPay API call order.
+
+## Scope
+
+- `POST /tickets/{amateurShowId}/reserve`
+- `POST /kakaoPay/ready`
+- `PATCH /myTickets/{realTicketId}/cancel`
+- Representative bad request handling for malformed body, missing request
+  parameter, and type mismatch errors
+
+## Baseline Added
+
+- `TempTicketCreateRequestDTO.quantity` must be positive.
+- `TempTicketServiceImpl.createTempTicket()` rejects `quantity <= 0` before
+  repository access, so service-level callers cannot bypass controller
+  validation.
+- Reserve request IDs are validated as positive values:
+  - `amateurShowId`
+  - `amateurRoundId`
+  - `amateurTicketId`
+- KakaoPay ready request validates `tempTicketId` as a positive value.
+- Ticket cancel request validates `realTicketId` as a positive value.
+- KakaoPay cancel/fail redirect fallback logs exceptions through the logger
+  instead of printing stack traces directly.
+
+## Error Handling
+
+The existing `ApiResponse` failure format is preserved. This baseline only adds
+minimal mapping for common malformed request cases:
+
+- Missing required request parameter
+- Request parameter/path variable type mismatch
+- Unreadable request body
+
+DTO validation still uses the existing `MethodArgumentNotValidException`
+handling path. Controller method validation uses existing `ErrorStatus` enum
+names in constraint messages so `ConstraintViolationException` remains
+compatible with the current handler.
+
+## Out Of Scope
+
+- Global exception contract redesign
+- Applying validation to every DTO in the project
+- Frontend error message mapping
+- Database schema changes or migrations
+- KakaoPay transaction boundary refactoring
+- `stopPayment` / scheduler race-condition refactoring
+- Payment status state-machine redesign
+
+## Follow-Up Work
+
+- Standardize the global exception response contract.
+- Add controller-level security and validation regression tests with `MockMvc`.
+- Expand request validation to board, comment, image, admin, and member APIs.
+- Remove remaining direct `printStackTrace()` calls across the whole codebase.
+- Document frontend error message mapping for ticket/payment failures.

--- a/src/main/java/cc/backend/apiPayLoad/exception/ExceptionAdvice.java
+++ b/src/main/java/cc/backend/apiPayLoad/exception/ExceptionAdvice.java
@@ -7,11 +7,14 @@ import cc.backend.apiPayLoad.code.status.ErrorStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -59,6 +62,24 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         });
 
         return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return handleExceptionInternalFalse(e, ErrorStatus._BAD_REQUEST, headers, ErrorStatus._BAD_REQUEST.getHttpStatus(), request, e.getMessage());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(
+            TypeMismatchException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return handleExceptionInternalFalse(e, ErrorStatus._BAD_REQUEST, headers, ErrorStatus._BAD_REQUEST.getHttpStatus(), request, e.getMessage());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return handleExceptionInternalFalse(e, ErrorStatus._BAD_REQUEST, headers, ErrorStatus._BAD_REQUEST.getHttpStatus(), request, e.getMessage());
     }
 
     //일반적인 예외 처리

--- a/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
+++ b/src/main/java/cc/backend/kakaoPay/controller/KakaoPayController.java
@@ -8,10 +8,13 @@ import cc.backend.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -20,6 +23,8 @@ import java.io.IOException;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/kakaoPay")
+@Validated
+@Slf4j
 public class KakaoPayController {
 
     private final KakaoPayBusinessService kakaoPayBusinessService;
@@ -30,7 +35,7 @@ public class KakaoPayController {
     // 결제 준비 요청 (결제 페이지에 대한 url 발급 요청)
     @PostMapping("/ready")
     @Operation(summary = "카카오페이 결제 준비", description = "카카오페이 결제창 URL을 발급합니다.")
-    public ApiResponse<KakaoPayReadyResponseDTO> preparePayment(@RequestParam Long tempTicketId,
+    public ApiResponse<KakaoPayReadyResponseDTO> preparePayment(@RequestParam @Positive(message = "_BAD_REQUEST") Long tempTicketId,
                                                        @AuthenticationPrincipal(expression = "member") Member member) {
         if (member == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
@@ -62,7 +67,7 @@ public class KakaoPayController {
                     frontendBaseUrl + "/ticketing/" + playId + "?payment=cancel"
             );
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("KakaoPay cancel redirect handling failed. partnerOrderId={}", partnerOrderId, e);
             response.sendRedirect(frontendBaseUrl);
         }
     }
@@ -77,7 +82,7 @@ public class KakaoPayController {
                     frontendBaseUrl + "/ticketing/" + playId + "?payment=fail"
             );
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("KakaoPay fail redirect handling failed. partnerOrderId={}", partnerOrderId, e);
             response.sendRedirect(frontendBaseUrl);
         }
     }

--- a/src/main/java/cc/backend/ticket/controller/MyTicketController.java
+++ b/src/main/java/cc/backend/ticket/controller/MyTicketController.java
@@ -13,9 +13,11 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/myTickets")
+@Validated
 public class MyTicketController {
     private final TempTicketService tempTicketService;
     private final RealTicketService realTicketService;
@@ -130,7 +133,7 @@ public class MyTicketController {
             }
     )
     public ApiResponse<RealTicketResponseDTO> cancelTicket(
-            @PathVariable Long realTicketId,
+            @PathVariable @Positive(message = "_BAD_REQUEST") Long realTicketId,
             @AuthenticationPrincipal(expression = "member") Member member) {
 
         RealTicketResponseDTO myTicket = kakaoPayBusinessService.cancelTicket(member.getId(), realTicketId);

--- a/src/main/java/cc/backend/ticket/controller/TempTicketController.java
+++ b/src/main/java/cc/backend/ticket/controller/TempTicketController.java
@@ -11,8 +11,11 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +25,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/tickets")
+@Validated
 public class TempTicketController {
 
     private final TempTicketService tempTicketService;
@@ -140,11 +144,11 @@ public class TempTicketController {
             }
     )
     public ApiResponse<TempTicketCreateResponseDTO> createTempTicket(
-            @PathVariable Long amateurShowId,
-            @RequestParam Long amateurRoundId,
-            @RequestParam Long amateurTicketId,
+            @PathVariable @Positive(message = "_BAD_REQUEST") Long amateurShowId,
+            @RequestParam @Positive(message = "_BAD_REQUEST") Long amateurRoundId,
+            @RequestParam @Positive(message = "_BAD_REQUEST") Long amateurTicketId,
             @AuthenticationPrincipal(expression = "member") Member member,
-            @RequestBody TempTicketCreateRequestDTO requestDTO) {
+            @Valid @RequestBody TempTicketCreateRequestDTO requestDTO) {
         return ApiResponse.onSuccess(
                 tempTicketService.createTempTicket(amateurShowId, amateurRoundId, amateurTicketId, member, requestDTO)
         );

--- a/src/main/java/cc/backend/ticket/dto/request/TempTicketCreateRequestDTO.java
+++ b/src/main/java/cc/backend/ticket/dto/request/TempTicketCreateRequestDTO.java
@@ -1,5 +1,6 @@
 package cc.backend.ticket.dto.request;
 
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class TempTicketCreateRequestDTO {
+    @Positive(message = "TEMP_TICKET_QUANTITY")
     private int quantity;               // 수량
 }

--- a/src/main/java/cc/backend/ticket/service/TempTicketServiceImpl.java
+++ b/src/main/java/cc/backend/ticket/service/TempTicketServiceImpl.java
@@ -44,6 +44,9 @@ public class TempTicketServiceImpl implements TempTicketService {
     @Override
     @Transactional
     public TempTicketCreateResponseDTO createTempTicket(Long amateurShowId, Long amateurRoundId, Long amateurTicketId, Member member, TempTicketCreateRequestDTO requestDTO) {
+        if (requestDTO == null || requestDTO.getQuantity() <= 0) {
+            throw new GeneralException(ErrorStatus.TEMP_TICKET_QUANTITY);
+        }
 
         Member memberRef = memberRepository.getReferenceById(member.getId());
         AmateurShow show = amateurShowRepository.findById(amateurShowId)

--- a/src/main/java/cc/backend/ticket/service/TempTicketServiceImpl.java
+++ b/src/main/java/cc/backend/ticket/service/TempTicketServiceImpl.java
@@ -48,10 +48,6 @@ public class TempTicketServiceImpl implements TempTicketService {
             throw new GeneralException(ErrorStatus.TEMP_TICKET_QUANTITY);
         }
 
-        if (requestDTO.getQuantity() <= 0) {
-            throw new GeneralException(ErrorStatus.TEMP_TICKET_QUANTITY);
-        }
-
         Member memberRef = memberRepository.getReferenceById(member.getId());
         AmateurShow show = amateurShowRepository.findById(amateurShowId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));

--- a/src/test/java/cc/backend/ticket/dto/request/TempTicketCreateRequestDTOTest.java
+++ b/src/test/java/cc/backend/ticket/dto/request/TempTicketCreateRequestDTOTest.java
@@ -1,0 +1,61 @@
+package cc.backend.ticket.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TempTicketCreateRequestDTOTest {
+
+    private static ValidatorFactory validatorFactory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @AfterAll
+    static void closeValidator() {
+        validatorFactory.close();
+    }
+
+    @Test
+    void quantityMustBePositive() {
+        assertQuantityViolation(0);
+        assertQuantityViolation(-1);
+    }
+
+    @Test
+    void positiveQuantityIsValid() {
+        TempTicketCreateRequestDTO requestDTO = TempTicketCreateRequestDTO.builder()
+                .quantity(1)
+                .build();
+
+        Set<ConstraintViolation<TempTicketCreateRequestDTO>> violations = validator.validate(requestDTO);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    private void assertQuantityViolation(int quantity) {
+        TempTicketCreateRequestDTO requestDTO = TempTicketCreateRequestDTO.builder()
+                .quantity(quantity)
+                .build();
+
+        Set<ConstraintViolation<TempTicketCreateRequestDTO>> violations = validator.validate(requestDTO);
+
+        assertEquals(1, violations.size());
+        ConstraintViolation<TempTicketCreateRequestDTO> violation = violations.iterator().next();
+        assertEquals("quantity", violation.getPropertyPath().toString());
+        assertEquals("TEMP_TICKET_QUANTITY", violation.getMessage());
+    }
+}

--- a/src/test/java/cc/backend/ticket/service/TempTicketServiceImplTest.java
+++ b/src/test/java/cc/backend/ticket/service/TempTicketServiceImplTest.java
@@ -1,0 +1,100 @@
+package cc.backend.ticket.service;
+
+import cc.backend.amateurShow.repository.AmateurRoundsRepository;
+import cc.backend.amateurShow.repository.AmateurShowRepository;
+import cc.backend.amateurShow.repository.AmateurTicketRepository;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.member.entity.Member;
+import cc.backend.member.repository.MemberRepository;
+import cc.backend.ticket.dto.request.TempTicketCreateRequestDTO;
+import cc.backend.ticket.repository.TempTicketRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class TempTicketServiceImplTest {
+
+    @Mock
+    private TempTicketRepository tempTicketRepository;
+
+    @Mock
+    private AmateurShowRepository amateurShowRepository;
+
+    @Mock
+    private AmateurTicketRepository amateurTicketRepository;
+
+    @Mock
+    private AmateurRoundsRepository amateurRoundsRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private RealTicketService realTicketService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private TempTicketServiceImpl tempTicketService;
+
+    @Test
+    void createTempTicket_rejectsZeroQuantity() {
+        assertInvalidQuantityRejected(0);
+    }
+
+    @Test
+    void createTempTicket_rejectsNegativeQuantity() {
+        assertInvalidQuantityRejected(-1);
+    }
+
+    @Test
+    void createTempTicket_rejectsNullRequest() {
+        Member member = mock(Member.class);
+
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> tempTicketService.createTempTicket(1L, 1L, 1L, member, null));
+
+        assertEquals(ErrorStatus.TEMP_TICKET_QUANTITY, exception.getCode());
+        verifyNoInteractions(
+                memberRepository,
+                amateurShowRepository,
+                amateurRoundsRepository,
+                amateurTicketRepository,
+                tempTicketRepository,
+                eventPublisher,
+                realTicketService
+        );
+    }
+
+    private void assertInvalidQuantityRejected(int quantity) {
+        TempTicketCreateRequestDTO requestDTO = TempTicketCreateRequestDTO.builder()
+                .quantity(quantity)
+                .build();
+        Member member = mock(Member.class);
+
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> tempTicketService.createTempTicket(1L, 1L, 1L, member, requestDTO));
+
+        assertEquals(ErrorStatus.TEMP_TICKET_QUANTITY, exception.getCode());
+        verifyNoInteractions(
+                memberRepository,
+                amateurShowRepository,
+                amateurRoundsRepository,
+                amateurTicketRepository,
+                tempTicketRepository,
+                eventPublisher,
+                realTicketService
+        );
+    }
+}


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - Part of #162

2. **📝 작업 내용**
    - 티켓/결제 요청값 validation baseline을 추가했습니다.
    - `quantity`는 `@Positive(message = "TEMP_TICKET_QUANTITY")`로 양수만 허용하도록 했습니다.
    - `/tickets/{amateurShowId}/reserve`, `/kakaoPay/ready`, `/myTickets/{realTicketId}/cancel`의 path/query parameter 양수 검증을 추가했습니다.
    - request param 누락, 타입 불일치, request body 파싱 실패를 기존 ApiResponse 실패 포맷의 `_BAD_REQUEST`로 매핑했습니다.
    - KakaoPay cancel/fail의 `printStackTrace()`를 `log.error(...)`로 교체했습니다.
    - 관련 DTO/service 테스트를 추가했습니다.

3. **💬 리뷰 요구사항**
    - `quantity` 검증을 DTO와 service 양쪽에서 방어하는 방식이 적절한지 확인 부탁드립니다.
    - request param/path variable 오류를 `_BAD_REQUEST`로 매핑한 방식이 기존 에러 응답 정책과 맞는지 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Strengthened request validation across ticket and payment endpoints; better handling and standardized 400 responses; replaced stack-trace prints with structured logging.

* **Documentation**
  * Added a baseline doc for ticket payment validation and minimal error-handling requirements.

* **Tests**
  * Added/updated validation tests for temp-ticket requests and service input rejection.

* **Chores**
  * CI workflow updated to use the Gradle wrapper and ensure it is executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->