### PR TITLE
[FIX] 인증 만료 및 토큰 갱신 흐름 안정화

### DIFF
--- a/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -33,7 +33,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_INVALID_CODE(HttpStatus.BAD_REQUEST, "MEMBER4004", "토큰이 유효하지 않습니다."),
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "MEMBER4005", "해당 사용자게에게 관리자 권한이 없습니다."),
     MEMBER_NOT_PERFORMER(HttpStatus.FORBIDDEN, "MEMBER4011", "등록자 계정이 아니기에 접근권한이 없습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER4012", "유효하지않은 리프레시 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "MEMBER4012", "유효하지않은 리프레시 토큰입니다."),
     INVALID_USERNAME_EMPTY(HttpStatus.BAD_REQUEST, "MEMBER4013", "유저네임 입력값이 비어있습니다."),
     INVALID_USERNAME_LENGTH(HttpStatus.BAD_REQUEST, "MEMBER4014", "유저네임은 1~20자로 설정해주세요 "),
     PHONENUM_ENCRYPT_FAIL(HttpStatus.BAD_REQUEST, "MEMBER4015", "전화번호 암호화 실패"),

--- a/src/main/java/cc/backend/auth/controller/AuthController.java
+++ b/src/main/java/cc/backend/auth/controller/AuthController.java
@@ -4,11 +4,14 @@ package cc.backend.auth.controller;
 import cc.backend.config.jwt.CustomUserDetails;
 import cc.backend.config.jwt.dto.TokenDTO;
 import cc.backend.config.jwt.TokenProvider;
+import cc.backend.config.jwt.dto.RefreshTokenRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth", description = "Auth API")
@@ -23,9 +26,22 @@ public class AuthController {
             summary = "로그아웃"
     )
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(Authentication authentication) {
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        tokenProvider.logout(userDetails.getMember().getId());
+    public ResponseEntity<Void> logout(
+            Authentication authentication,
+            @RequestBody(required = false) RefreshTokenRequest request
+    ) {
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            tokenProvider.logout(userDetails.getMember().getId());
+        } else if (request != null && StringUtils.hasText(request.getRefreshToken())) {
+            tokenProvider.logoutByRefreshToken(request.getRefreshToken());
+        }
+
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "액세스 토큰 재발급")
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenDTO> refresh(@Valid @RequestBody RefreshTokenRequest request) {
+        return ResponseEntity.ok(tokenProvider.refreshAccessToken(request.getRefreshToken()));
     }
 }

--- a/src/main/java/cc/backend/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/cc/backend/config/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package cc.backend.config.jwt;
+
+import cc.backend.apiPayLoad.ApiResponse;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        ErrorStatus status = ErrorStatus._FORBIDDEN;
+        response.setStatus(status.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(
+                response.getWriter(),
+                ApiResponse.onFailure(status.getCode(), status.getMessage(), null)
+        );
+    }
+}

--- a/src/main/java/cc/backend/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/cc/backend/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package cc.backend.config.jwt;
+
+import cc.backend.apiPayLoad.ApiResponse;
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        ErrorStatus status = ErrorStatus._UNAUTHORIZED;
+        response.setStatus(status.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(
+                response.getWriter(),
+                ApiResponse.onFailure(status.getCode(), status.getMessage(), null)
+        );
+    }
+}

--- a/src/main/java/cc/backend/config/jwt/JwtFilter.java
+++ b/src/main/java/cc/backend/config/jwt/JwtFilter.java
@@ -43,10 +43,8 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // 2. validateToken 으로 토큰 유효성 검사
         if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-            log.info("벨리데이트 토큰 통과함");
             Authentication authentication = tokenProvider.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-            log.info(" 현재 인증 정보: {}", authentication);
         }
 
         filterChain.doFilter(request, response);
@@ -56,13 +54,9 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        log.info("🔍 Received Authorization Header: {}", bearerToken);
 
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            //String token = bearerToken.split(" ")[1].trim();
-            String token = bearerToken.substring(BEARER_PREFIX.length()).trim();
-            log.info("🔍 Extracted JWT Token: {}", token);
-            return token;
+            return bearerToken.substring(BEARER_PREFIX.length()).trim();
         }
         return null;
     }

--- a/src/main/java/cc/backend/config/jwt/SecurityConfig.java
+++ b/src/main/java/cc/backend/config/jwt/SecurityConfig.java
@@ -23,8 +23,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 @EnableMethodSecurity
 public class SecurityConfig {
-    private final TokenProvider tokenProvider;
     private final JwtFilter jwtFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Value("${cors.allowed-origins}")
     private String allowedOrigins;
@@ -58,12 +59,23 @@ public class SecurityConfig {
                 )
                 .httpBasic(httpBasic -> httpBasic.disable()) // HTTP Basic 비활성화
                 .formLogin(formLogin -> formLogin.disable()) // 폼 로그인 비활성화
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/actuator/health").permitAll()  // 헬스체크 허용
                         .requestMatchers("/actuator/info").permitAll()
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.POST,
+                                "/auth/refresh",
+                                "/auth/logout",
+                                "/auth/kakao/callback",
+                                "/auth/dev/login",
+                                "/auth/dev/refresh"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/login/oauth2/code/google").permitAll()
 
                         .requestMatchers(HttpMethod.GET, "/kakaoPay/approve", "/kakaoPay/cancel", "/kakaoPay/fail").permitAll()
                         .requestMatchers(HttpMethod.POST, "/kakaoPay/ready").authenticated()
@@ -86,8 +98,6 @@ public class SecurityConfig {
                         .requestMatchers("/upload/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .apply(new JwtSecurityConfig(tokenProvider));
-        http
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class); // JwtFilter 등록
 
         return http.build();

--- a/src/main/java/cc/backend/config/jwt/TokenProvider.java
+++ b/src/main/java/cc/backend/config/jwt/TokenProvider.java
@@ -15,6 +15,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.security.Key;
 import java.util.Base64;
@@ -107,13 +108,13 @@ public class TokenProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("잘못된 JWT 서명입니다.");
+            log.debug("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
+            log.debug("만료된 JWT 토큰입니다.");
         } catch (UnsupportedJwtException e) {
-            log.info("지원되지 않는 JWT 토큰입니다.");
+            log.debug("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
-            log.info("JWT 토큰이 잘못되었습니다.");
+            log.debug("JWT 토큰이 잘못되었습니다.");
         }
         return false;
     }
@@ -151,5 +152,20 @@ public class TokenProvider {
 
     public void logout(Long memberId) {
         refreshTokenService.deleteRefreshToken(memberId);
+    }
+
+    public void logoutByRefreshToken(String refreshToken) {
+        if (!StringUtils.hasText(refreshToken)) {
+            return;
+        }
+
+        try {
+            Long memberId = Long.valueOf(parseClaims(refreshToken).getSubject());
+            if (refreshTokenService.validateRefreshToken(memberId, refreshToken)) {
+                refreshTokenService.deleteRefreshToken(memberId);
+            }
+        } catch (JwtException | IllegalArgumentException e) {
+            log.debug("로그아웃 요청의 refresh token을 확인할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/cc/backend/config/jwt/dto/RefreshTokenRequest.java
+++ b/src/main/java/cc/backend/config/jwt/dto/RefreshTokenRequest.java
@@ -1,5 +1,6 @@
 package cc.backend.config.jwt.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RefreshTokenRequest {
+    @NotBlank(message = "_BAD_REQUEST")
     private String refreshToken;
 }

--- a/src/test/java/cc/backend/auth/controller/AuthControllerTest.java
+++ b/src/test/java/cc/backend/auth/controller/AuthControllerTest.java
@@ -1,0 +1,77 @@
+package cc.backend.auth.controller;
+
+import cc.backend.config.jwt.CustomUserDetails;
+import cc.backend.config.jwt.TokenProvider;
+import cc.backend.config.jwt.dto.RefreshTokenRequest;
+import cc.backend.config.jwt.dto.TokenDTO;
+import cc.backend.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private Authentication authentication;
+
+    private AuthController authController;
+
+    @BeforeEach
+    void setUp() {
+        authController = new AuthController(tokenProvider);
+    }
+
+    @Test
+    void logoutDeletesRefreshTokenForAuthenticatedMember() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(7L);
+        when(authentication.getPrincipal()).thenReturn(new CustomUserDetails(member));
+
+        assertThat(authController.logout(authentication, null).getStatusCode().is2xxSuccessful()).isTrue();
+
+        verify(tokenProvider).logout(7L);
+        verify(tokenProvider, never()).logoutByRefreshToken(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void logoutUsesRefreshTokenWhenAccessTokenAuthenticationIsMissing() {
+        RefreshTokenRequest request = new RefreshTokenRequest("refresh-token");
+
+        assertThat(authController.logout(null, request).getStatusCode().is2xxSuccessful()).isTrue();
+
+        verify(tokenProvider).logoutByRefreshToken("refresh-token");
+    }
+
+    @Test
+    void logoutWithoutAuthenticationOrBodyIsIdempotent() {
+        assertThat(authController.logout(null, null).getStatusCode().is2xxSuccessful()).isTrue();
+
+        verifyNoInteractions(tokenProvider);
+    }
+
+    @Test
+    void refreshDelegatesToTokenProvider() {
+        RefreshTokenRequest request = new RefreshTokenRequest("refresh-token");
+        TokenDTO tokenDTO = TokenDTO.builder()
+                .accessToken("new-access-token")
+                .refreshToken("refresh-token")
+                .build();
+        when(tokenProvider.refreshAccessToken("refresh-token")).thenReturn(tokenDTO);
+
+        assertThat(authController.refresh(request).getBody()).isSameAs(tokenDTO);
+    }
+}

--- a/src/test/java/cc/backend/config/jwt/SecurityConfigPublicEndpointBaselineTest.java
+++ b/src/test/java/cc/backend/config/jwt/SecurityConfigPublicEndpointBaselineTest.java
@@ -28,7 +28,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @WebMvcTest(controllers = SecurityConfigPublicEndpointBaselineTest.BaselineController.class)
-@Import({SecurityConfig.class, SecurityConfigPublicEndpointBaselineTest.TestSecurityBeans.class})
+@Import({
+        SecurityConfig.class,
+        JwtAuthenticationEntryPoint.class,
+        JwtAccessDeniedHandler.class,
+        SecurityConfigPublicEndpointBaselineTest.TestSecurityBeans.class
+})
 @TestPropertySource(properties = "cors.allowed-origins=http://localhost:*")
 class SecurityConfigPublicEndpointBaselineTest {
 
@@ -57,13 +62,28 @@ class SecurityConfigPublicEndpointBaselineTest {
     @WithAnonymousUser
     void privateEndpointsBlockAnonymousRequests() throws Exception {
         mockMvc.perform(post("/kakaoPay/ready?tempTicketId=1"))
-                .andExpect(authBlocked());
+                .andExpect(unauthorized());
         mockMvc.perform(get("/myTickets/list"))
-                .andExpect(authBlocked());
+                .andExpect(unauthorized());
         mockMvc.perform(get("/member/myPage"))
-                .andExpect(authBlocked());
+                .andExpect(unauthorized());
         mockMvc.perform(get("/admin/dashboard/approval"))
-                .andExpect(authBlocked());
+                .andExpect(unauthorized());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void authEndpointsUseExplicitPublicRules() throws Exception {
+        mockMvc.perform(post("/auth/refresh"))
+                .andExpect(notAuthBlocked());
+        mockMvc.perform(post("/auth/logout"))
+                .andExpect(notAuthBlocked());
+        mockMvc.perform(post("/auth/kakao/callback"))
+                .andExpect(notAuthBlocked());
+        mockMvc.perform(get("/login/oauth2/code/google"))
+                .andExpect(notAuthBlocked());
+        mockMvc.perform(get("/auth/internal"))
+                .andExpect(unauthorized());
     }
 
     private static ResultMatcher notAuthBlocked() {
@@ -71,9 +91,9 @@ class SecurityConfigPublicEndpointBaselineTest {
                 .isNotIn(HttpServletResponse.SC_UNAUTHORIZED, HttpServletResponse.SC_FORBIDDEN);
     }
 
-    private static ResultMatcher authBlocked() {
+    private static ResultMatcher unauthorized() {
         return result -> assertThat(result.getResponse().getStatus())
-                .isIn(HttpServletResponse.SC_UNAUTHORIZED, HttpServletResponse.SC_FORBIDDEN);
+                .isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
     }
 
     @RestController
@@ -92,6 +112,25 @@ class SecurityConfigPublicEndpointBaselineTest {
 
         @PostMapping("/kakaoPay/ready")
         String kakaoPayReady() {
+            return "ok";
+        }
+
+        @PostMapping({
+                "/auth/refresh",
+                "/auth/logout",
+                "/auth/kakao/callback"
+        })
+        String publicAuthEndpoint() {
+            return "ok";
+        }
+
+        @GetMapping("/login/oauth2/code/google")
+        String googleCallback() {
+            return "ok";
+        }
+
+        @GetMapping("/auth/internal")
+        String privateAuthEndpoint() {
             return "ok";
         }
 

--- a/src/test/java/cc/backend/config/jwt/TokenProviderLogoutTest.java
+++ b/src/test/java/cc/backend/config/jwt/TokenProviderLogoutTest.java
@@ -1,0 +1,75 @@
+package cc.backend.config.jwt;
+
+import cc.backend.member.repository.MemberRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Key;
+import java.util.Date;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TokenProviderLogoutTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    private TokenProvider tokenProvider;
+    private Key key;
+
+    @BeforeEach
+    void setUp() {
+        key = Keys.secretKeyFor(SignatureAlgorithm.HS512);
+        String secret = Encoders.BASE64.encode(key.getEncoded());
+        tokenProvider = new TokenProvider(secret, memberRepository, refreshTokenService);
+    }
+
+    @Test
+    void logoutByRefreshTokenDeletesMatchingStoredToken() {
+        String refreshToken = refreshToken(11L);
+        when(refreshTokenService.validateRefreshToken(11L, refreshToken)).thenReturn(true);
+
+        tokenProvider.logoutByRefreshToken(refreshToken);
+
+        verify(refreshTokenService).deleteRefreshToken(11L);
+    }
+
+    @Test
+    void logoutByRefreshTokenDoesNotDeleteNonMatchingToken() {
+        String refreshToken = refreshToken(11L);
+        when(refreshTokenService.validateRefreshToken(11L, refreshToken)).thenReturn(false);
+
+        tokenProvider.logoutByRefreshToken(refreshToken);
+
+        verify(refreshTokenService, never()).deleteRefreshToken(11L);
+    }
+
+    @Test
+    void logoutByRefreshTokenIgnoresMalformedToken() {
+        tokenProvider.logoutByRefreshToken("not-a-jwt");
+
+        verifyNoInteractions(refreshTokenService);
+    }
+
+    private String refreshToken(Long memberId) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .setExpiration(new Date(System.currentTimeMillis() + 60_000))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+}

--- a/src/test/java/cc/backend/config/jwt/dto/RefreshTokenRequestTest.java
+++ b/src/test/java/cc/backend/config/jwt/dto/RefreshTokenRequestTest.java
@@ -1,0 +1,21 @@
+package cc.backend.config.jwt.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RefreshTokenRequestTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void refreshTokenMustNotBeBlank() {
+        RefreshTokenRequest request = new RefreshTokenRequest(" ");
+
+        assertThat(validator.validate(request))
+                .singleElement()
+                .satisfies(violation -> assertThat(violation.getMessage()).isEqualTo("_BAD_REQUEST"));
+    }
+}


### PR DESCRIPTION
#⃣ 연관된 이슈
- Part of #162 

📝 작업 내용
FE 인증 세션 안정화 작업과 맞춰, 백엔드의 access token 만료·refresh·logout 처리 계약을 정리했습니다.
- POST /auth/refresh API를 정식 추가했습니다.
- POST /auth/logout을 null-safe·멱등하게 처리하도록 보강했습니다.
  - request body가 없거나, refresh token이 이미 만료된 경우에도 200으로 처리합니다.
- refresh token만으로도 Redis에 저장된 토큰 정보를 삭제할 수 있도록 보강했습니다.
- 기존의 광범위한 /auth/** permitAll 설정을 제거하고, OAuth·refresh·logout 등 필요한 인증 엔드포인트만 공개하도록 정리했습니다.
- 인증되지 않은 요청은 401, 권한이 부족한 요청은 403으로 분리되도록 조정했습니다.
- invalid refresh token 응답을 401로 정리했습니다.
- Authorization 헤더와 JWT 원문이 로그에 남지 않도록 민감 로그를 제거했습니다.
- JWT 필터가 중복 등록되지 않도록 정리했습니다.

💬 리뷰 요구사항
- POST /auth/refresh 요청/응답 계약이 FE의 token refresh 흐름과 맞는지 확인 부탁드립니다.
- logout을 null-safe·멱등 처리하는 방식이 현재 인증 정책과 맞는지 검토 부탁드립니다.
- /auth/** permitAll을 제거하고 필요한 OAuth/refresh/logout endpoint만 공개한 방식이 누락 없이 적절한지 확인 부탁드립니다.
- 익명 요청 401, 권한 부족 403으로 분리한 처리가 기존 private API 기대 동작과 충돌하지 않는지 확인 부탁드립니다.