### PR TITLE
[FIX] 관리자 티켓 API 권한 차단 및 403 응답 처리 보강

### DIFF
--- a/src/main/java/cc/backend/admin/ticket/AdminTicketController.java
+++ b/src/main/java/cc/backend/admin/ticket/AdminTicketController.java
@@ -12,12 +12,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.*;
 import org.springframework.data.domain.Page;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "관리자 소극장 티켓 관리")
 @RequestMapping("/admin/ticket")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminTicketController {
 
     private final AdminTicketService adminTicketService;

--- a/src/main/java/cc/backend/apiPayLoad/exception/ExceptionAdvice.java
+++ b/src/main/java/cc/backend/apiPayLoad/exception/ExceptionAdvice.java
@@ -86,7 +86,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
     public ResponseEntity<Object> accessDenied(Exception e, WebRequest request) {
-        return handleExceptionInternalFalse(e, ErrorStatus._FORBIDDEN, HttpHeaders.EMPTY, ErrorStatus._FORBIDDEN.getHttpStatus(), request, e.getMessage());
+        return handleExceptionInternalFalse(e, ErrorStatus._FORBIDDEN, HttpHeaders.EMPTY, ErrorStatus._FORBIDDEN.getHttpStatus(), request, null);
     }
 
     //일반적인 예외 처리

--- a/src/main/java/cc/backend/apiPayLoad/exception/ExceptionAdvice.java
+++ b/src/main/java/cc/backend/apiPayLoad/exception/ExceptionAdvice.java
@@ -13,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -80,6 +82,11 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     protected ResponseEntity<Object> handleHttpMessageNotReadable(
             HttpMessageNotReadableException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         return handleExceptionInternalFalse(e, ErrorStatus._BAD_REQUEST, headers, ErrorStatus._BAD_REQUEST.getHttpStatus(), request, e.getMessage());
+    }
+
+    @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
+    public ResponseEntity<Object> accessDenied(Exception e, WebRequest request) {
+        return handleExceptionInternalFalse(e, ErrorStatus._FORBIDDEN, HttpHeaders.EMPTY, ErrorStatus._FORBIDDEN.getHttpStatus(), request, e.getMessage());
     }
 
     //일반적인 예외 처리

--- a/src/test/java/cc/backend/admin/ticket/AdminTicketControllerSecurityTest.java
+++ b/src/test/java/cc/backend/admin/ticket/AdminTicketControllerSecurityTest.java
@@ -1,0 +1,108 @@
+package cc.backend.admin.ticket;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import cc.backend.apiPayLoad.PageResponse;
+import cc.backend.config.jwt.JwtFilter;
+import cc.backend.config.jwt.MethodSecurityConfig;
+import cc.backend.config.jwt.SecurityConfig;
+import cc.backend.config.jwt.TokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AdminTicketController.class)
+@Import({SecurityConfig.class, MethodSecurityConfig.class, AdminTicketControllerSecurityTest.TestSecurityBeans.class})
+@TestPropertySource(properties = "cors.allowed-origins=http://localhost:*")
+class AdminTicketControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminTicketService adminTicketService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void adminCanAccessTicketHistory() throws Exception {
+        when(adminTicketService.getTicketList(anyInt(), anyInt(), nullable(String.class)))
+                .thenReturn(new PageResponse<>(List.of(), 0, 20, 0, 0));
+
+        mockMvc.perform(get("/admin/ticket/history?page=0&size=20"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = "AUDIENCE")
+    void audienceCannotAccessTicketHistory() throws Exception {
+        mockMvc.perform(get("/admin/ticket/history?page=0&size=20"))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(adminTicketService);
+    }
+
+    @Test
+    @WithMockUser(roles = "PERFORMER")
+    void performerCannotAccessTicketHistory() throws Exception {
+        mockMvc.perform(get("/admin/ticket/history?page=0&size=20"))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(adminTicketService);
+    }
+
+    @TestConfiguration
+    static class TestSecurityBeans {
+
+        @Bean
+        TokenProvider tokenProvider() {
+            return mock(TokenProvider.class);
+        }
+
+        @Bean
+        JwtFilter jwtFilter(TokenProvider tokenProvider) {
+            return new PassThroughJwtFilter(tokenProvider);
+        }
+    }
+
+    private static class PassThroughJwtFilter extends JwtFilter {
+
+        PassThroughJwtFilter(TokenProvider tokenProvider) {
+            super(tokenProvider);
+        }
+
+        @Override
+        protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws ServletException, IOException {
+            if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/src/test/java/cc/backend/admin/ticket/AdminTicketControllerSecurityTest.java
+++ b/src/test/java/cc/backend/admin/ticket/AdminTicketControllerSecurityTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import cc.backend.apiPayLoad.PageResponse;
+import cc.backend.config.jwt.JwtAccessDeniedHandler;
+import cc.backend.config.jwt.JwtAuthenticationEntryPoint;
 import cc.backend.config.jwt.JwtFilter;
 import cc.backend.config.jwt.MethodSecurityConfig;
 import cc.backend.config.jwt.SecurityConfig;
@@ -45,6 +47,12 @@ class AdminTicketControllerSecurityTest {
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Test
     @WithMockUser(roles = "ADMIN")


### PR DESCRIPTION
## 1. #⃣ 연관된 이슈

## 2. 📝 작업 내용

관리자 QA 과정에서 확인된 `/admin/ticket/**` 권한 차단 누락과 권한 실패 응답 처리 문제를 수정했습니다.

주요 작업 내용은 다음과 같습니다.

- `AdminTicketController` 관리자 권한 제한 보강
  - `/admin/ticket/**` 관련 컨트롤러에 `@PreAuthorize("hasRole('ADMIN')")` 추가
  - 비관리자 사용자가 관리자 티켓 API에 접근하지 못하도록 차단

- 권한 실패 응답 처리 보강
  - `ExceptionAdvice`에 `AccessDeniedException` 전용 403 처리 추가
  - `AuthorizationDeniedException` 전용 403 처리 추가
  - 권한 부족 상황에서 서버 에러가 아닌 명확한 403 응답이 내려가도록 정리

- 관리자 티켓 보안 테스트 추가
  - `AdminTicketControllerSecurityTest` 추가
  - 관리자 권한이 필요한 API에 대해 비관리자 접근 차단 여부 검증

- develop 최신 변경 반영 및 테스트 컨텍스트 보강
  - origin/develop 최신화 후 현재 브랜치에 merge
  - 인증 안정화 작업으로 늘어난 `SecurityConfig` 의존성에 맞춰 테스트 설정 보강
  - conflict 없이 merge 완료

## 4. 💬 리뷰 요구사항

- `/admin/ticket/**`에 `@PreAuthorize("hasRole('ADMIN')")`를 적용한 위치가 적절한지
- 권한 실패 상황에서 `AccessDeniedException`, `AuthorizationDeniedException`을 403으로 처리하는 방식이 기존 에러 응답 규칙과 맞는지
- `AdminTicketControllerSecurityTest`의 테스트 컨텍스트 보강 방식이 현재 `SecurityConfig` 구조와 잘 맞는지
- dev/staging 배포 전 추가로 확인해야 할 관리자 API 권한 경계가 있는지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin ticket endpoints now enforce role-based access control, restricting access to users with the ADMIN role.

* **Improvements**
  * Authorization failures now return proper FORBIDDEN (403) status with detailed error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->