### PR TITLE
feat: [임시] 앱 심사용 일반 로그인 추가

### DIFF
--- a/src/main/java/cc/backend/auth/review/ReviewAccounts.java
+++ b/src/main/java/cc/backend/auth/review/ReviewAccounts.java
@@ -1,0 +1,23 @@
+package cc.backend.auth.review;
+
+import cc.backend.member.enumerate.Role;
+
+import java.util.Map;
+
+/**
+ * [임시] 앱 심사용 일반 로그인 허용 계정 화이트리스트.
+ *
+ * 비밀번호는 DB에 직접 INSERT 한 계정의 값으로 검증한다.
+ * 심사 통과 후 review 패키지 전체와 SecurityConfig 변경분을 함께 revert 한다.
+ */
+public final class ReviewAccounts {
+
+    private ReviewAccounts() {
+    }
+
+    /** 일반 로그인을 허용할 심사용 계정 (이메일 -> 역할) */
+    public static final Map<String, Role> WHITELIST = Map.of(
+            "user1@test.com", Role.AUDIENCE,
+            "performer1@test.com", Role.PERFORMER
+    );
+}

--- a/src/main/java/cc/backend/auth/review/ReviewAuthController.java
+++ b/src/main/java/cc/backend/auth/review/ReviewAuthController.java
@@ -1,0 +1,63 @@
+package cc.backend.auth.review;
+
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.config.jwt.TokenProvider;
+import cc.backend.config.jwt.dto.TokenDTO;
+import cc.backend.member.entity.Member;
+import cc.backend.member.repository.MemberRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * [임시] 앱 심사용 일반 로그인 컨트롤러.
+ *
+ * 운영 환경에서도 동작하며, {@link ReviewAccounts#WHITELIST} 에 등록된 계정만
+ * 이메일 + 비밀번호로 로그인할 수 있다. 심사 통과 후 revert 대상.
+ */
+@Tag(name = "Auth", description = "Auth API")
+@RestController
+@RequestMapping("/auth/review")
+@RequiredArgsConstructor
+public class ReviewAuthController {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+
+    @Operation(
+            summary = "[임시] 앱 심사용 일반 로그인",
+            description = "심사용 화이트리스트 계정에 한해 이메일/비밀번호로 토큰을 발급합니다. 심사 종료 후 제거 예정."
+    )
+    @PostMapping("/login")
+    public ResponseEntity<TokenDTO> login(@RequestBody LoginRequest req) {
+        // 화이트리스트에 없는 계정은 거부 (운영 일반 사용자 차단)
+        if (!ReviewAccounts.WHITELIST.containsKey(req.getEmail())) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_AUTHORIZED);
+        }
+
+        Member member = memberRepository.findMemberByEmail(req.getEmail())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(req.getPassword(), member.getPassword())) {
+            throw new GeneralException(ErrorStatus.PASSWORD_NOT_MATCH);
+        }
+
+        return ResponseEntity.ok(tokenProvider.generateTokenDto(member));
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class LoginRequest {
+        private String email;
+        private String password;
+    }
+}

--- a/src/main/java/cc/backend/config/jwt/SecurityConfig.java
+++ b/src/main/java/cc/backend/config/jwt/SecurityConfig.java
@@ -73,7 +73,8 @@ public class SecurityConfig {
                                 "/auth/logout",
                                 "/auth/kakao/callback",
                                 "/auth/dev/login",
-                                "/auth/dev/refresh"
+                                "/auth/dev/refresh",
+                                "/auth/review/login" // [임시] 앱 심사용 일반 로그인, 심사 후 revert
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/login/oauth2/code/google").permitAll()
 


### PR DESCRIPTION
- 화이트리스트(user1@test.com, performer1@test.com) 계정만 이메일/비밀번호 로그인 허용
- POST /auth/review/login (운영 환경 동작, DB 비밀번호 검증)
- 계정/비밀번호는 DB에 수동 INSERT (앱/설정에 비번 미보관)
- 심사 통과 후 본 커밋 revert 예정

1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - 예: `#이슈번호`, `#이슈번호`
2. **📝 작업 내용**
    - 이번 PR에서 작업한 내용을 간략히 설명해주세요.
    - 필요한 경우 이미지 첨부 가능.
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added review account login endpoint with email and password authentication
  * Login access restricted to whitelisted review accounts only
  * Returns authentication token upon successful login
  * Includes error handling for unauthorized accounts, missing members, and incorrect passwords

<!-- end of auto-generated comment: release notes by coderabbit.ai -->