### PR TITLE
[FIX] 카카오 회원가입 선택 정보 누락 허용

### DIFF
--- a/src/main/java/cc/backend/auth/service/AuthService.java
+++ b/src/main/java/cc/backend/auth/service/AuthService.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.Optional;
 import java.util.Random;
@@ -46,7 +47,15 @@ public class AuthService {
     }
 
     private Member findOrCreateMember(KakaoUserInfo userInfo, Role role) {
+        if (userInfo == null || userInfo.getId() == null || userInfo.getKakaoAccount() == null) {
+            throw new GeneralException(ErrorStatus.INVALID_KAKAO_USER_INFO);
+        }
+
         String email = userInfo.getKakaoAccount().getEmail();
+        if (!StringUtils.hasText(email)) {
+            throw new GeneralException(ErrorStatus.INVALID_KAKAO_USER_INFO);
+        }
+
         String kakaoId = userInfo.getId().toString();
 
         // 1차: kakaoId로 조회
@@ -103,29 +112,14 @@ public class AuthService {
         }
 
         // 기존 멤버가 아닌 경우 새 맴버 생성
-        String nickname = userInfo.getProperties().getNickname();
-        String name = userInfo.getKakaoAccount().getName();
+        String nickname = resolveNickname(userInfo, email);
+        String name = resolveName(userInfo, nickname);
+        String encryptedPhone = encryptPhoneIfPresent(userInfo.getKakaoAccount().getPhoneNumber());
 
-        String encryptedPhone;
-        try {
-            encryptedPhone = AESUtil.encrypt(userInfo.getKakaoAccount().getPhoneNumber());
-        } catch (Exception e) {
-            throw new GeneralException(ErrorStatus.PHONENUM_ENCRYPT_FAIL);
-        }
-
-        if (email == null || nickname == null || name == null)  {
-            log.error("필수 정보 누락 - 이메일: {}, 닉네임: {}, 이름: {}, 전화번호: {}",
-                    email, nickname, name, encryptedPhone);
-            throw new GeneralException(ErrorStatus.INVALID_KAKAO_USER_INFO);
-        }
-
-        return createNewMember(userInfo, role, kakaoId, encryptedPhone);
+        return createNewMember(email, nickname, name, role, kakaoId, encryptedPhone);
     }
 
-    private Member createNewMember(KakaoUserInfo userInfo, Role role, String kakaoId, String encryptedPhone) {
-        String email = userInfo.getKakaoAccount().getEmail();
-        String nickname = userInfo.getProperties().getNickname();
-        String name = userInfo.getKakaoAccount().getName();
+    private Member createNewMember(String email, String nickname, String name, Role role, String kakaoId, String encryptedPhone) {
         String username = generateUsername(nickname);
 
         Member newMember = Member.builder()
@@ -192,16 +186,12 @@ public class AuthService {
 
     //비활성화된 회원 재활성화
     private Member reactivateMember(Member member, KakaoUserInfo userInfo, Role newRole, String kakaoId) {
-        String name = userInfo.getKakaoAccount().getName();
-        String nickname = userInfo.getProperties().getNickname();
+        String email = userInfo.getKakaoAccount().getEmail();
+        String nickname = resolveNickname(userInfo, email);
+        String name = resolveName(userInfo, nickname);
         String newUsername = generateUsername(nickname);
 
-        String encryptedPhone;
-        try {
-            encryptedPhone = AESUtil.encrypt(userInfo.getKakaoAccount().getPhoneNumber());
-        } catch (Exception e) {
-            throw new GeneralException(ErrorStatus.PHONENUM_ENCRYPT_FAIL);
-        }
+        String encryptedPhone = encryptPhoneIfPresent(userInfo.getKakaoAccount().getPhoneNumber());
 
         // 회원 정보 업데이트 및 재활성화
         member.reactivateMember();
@@ -226,5 +216,34 @@ public class AuthService {
         // CASE 3: 기존 계정의 kakaoId와 현재 로그인한 kakaoId가 동일한 경우
         // → 정상적인 재로그인이므로 추가 처리 없이 그대로 진행
         return member;
+    }
+
+    private String resolveNickname(KakaoUserInfo userInfo, String email) {
+        if (userInfo.getProperties() != null && StringUtils.hasText(userInfo.getProperties().getNickname())) {
+            return userInfo.getProperties().getNickname();
+        }
+
+        int atIndex = email.indexOf("@");
+        return atIndex > 0 ? email.substring(0, atIndex) : email;
+    }
+
+    private String resolveName(KakaoUserInfo userInfo, String fallbackName) {
+        if (userInfo.getKakaoAccount() != null && StringUtils.hasText(userInfo.getKakaoAccount().getName())) {
+            return userInfo.getKakaoAccount().getName();
+        }
+
+        return fallbackName;
+    }
+
+    private String encryptPhoneIfPresent(String phoneNumber) {
+        if (!StringUtils.hasText(phoneNumber)) {
+            return null;
+        }
+
+        try {
+            return AESUtil.encrypt(phoneNumber);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.PHONENUM_ENCRYPT_FAIL);
+        }
     }
 }

--- a/src/test/java/cc/backend/auth/service/AuthServiceTest.java
+++ b/src/test/java/cc/backend/auth/service/AuthServiceTest.java
@@ -1,0 +1,164 @@
+package cc.backend.auth.service;
+
+import cc.backend.apiPayLoad.code.status.ErrorStatus;
+import cc.backend.apiPayLoad.exception.GeneralException;
+import cc.backend.auth.kakao.KakaoClient;
+import cc.backend.auth.kakao.dto.response.KakaoTokenResponse;
+import cc.backend.auth.kakao.dto.response.KakaoUserInfo;
+import cc.backend.config.jwt.TokenProvider;
+import cc.backend.config.jwt.dto.TokenDTO;
+import cc.backend.member.entity.Member;
+import cc.backend.member.enumerate.Role;
+import cc.backend.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    private static final String REDIRECT_URI = "https://seeatheater.store/auth/kakao/callback";
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(kakaoClient, memberRepository, tokenProvider);
+    }
+
+    @Test
+    void kakaoLoginCreatesMemberWhenOptionalNameAndPhoneAreMissing() throws Exception {
+        KakaoTokenResponse kakaoToken = kakaoToken();
+        KakaoUserInfo userInfo = kakaoUserInfo("""
+                {
+                  "id": 12345,
+                  "kakao_account": {
+                    "email": "seeatheater@gmail.com"
+                  },
+                  "properties": {
+                    "nickname": "SeeATheater"
+                  }
+                }
+                """);
+        TokenDTO tokenDTO = TokenDTO.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .build();
+
+        when(kakaoClient.getAccessToken("code", REDIRECT_URI)).thenReturn(kakaoToken);
+        when(kakaoClient.getUserInfo("kakao-access-token")).thenReturn(userInfo);
+        when(memberRepository.findMemberByKakaoId("12345")).thenReturn(Optional.empty());
+        when(memberRepository.findMemberByEmail("seeatheater@gmail.com")).thenReturn(Optional.empty());
+        when(memberRepository.existsByUsername(anyString())).thenReturn(false);
+        when(memberRepository.save(any(Member.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tokenProvider.generateTokenDto(any(Member.class))).thenReturn(tokenDTO);
+
+        TokenDTO result = authService.kakaoLogin("code", REDIRECT_URI, Role.AUDIENCE);
+
+        assertThat(result).isSameAs(tokenDTO);
+
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+
+        Member savedMember = memberCaptor.getValue();
+        assertThat(savedMember.getEmail()).isEqualTo("seeatheater@gmail.com");
+        assertThat(savedMember.getRole()).isEqualTo(Role.AUDIENCE);
+        assertThat(savedMember.getKakaoId()).isEqualTo("12345");
+        assertThat(savedMember.getName()).isEqualTo("SeeATheater");
+        assertThat(savedMember.getUsername()).startsWith("SeeATheater");
+        assertThat(savedMember.getPhone()).isNull();
+    }
+
+    @Test
+    void kakaoLoginFallsBackToEmailLocalPartWhenNicknameNameAndPhoneAreMissing() throws Exception {
+        KakaoTokenResponse kakaoToken = kakaoToken();
+        KakaoUserInfo userInfo = kakaoUserInfo("""
+                {
+                  "id": 67890,
+                  "kakao_account": {
+                    "email": "seeatheater@gmail.com"
+                  }
+                }
+                """);
+        TokenDTO tokenDTO = TokenDTO.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .build();
+
+        when(kakaoClient.getAccessToken("code", REDIRECT_URI)).thenReturn(kakaoToken);
+        when(kakaoClient.getUserInfo("kakao-access-token")).thenReturn(userInfo);
+        when(memberRepository.findMemberByKakaoId("67890")).thenReturn(Optional.empty());
+        when(memberRepository.findMemberByEmail("seeatheater@gmail.com")).thenReturn(Optional.empty());
+        when(memberRepository.existsByUsername(anyString())).thenReturn(false);
+        when(memberRepository.save(any(Member.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tokenProvider.generateTokenDto(any(Member.class))).thenReturn(tokenDTO);
+
+        authService.kakaoLogin("code", REDIRECT_URI, Role.AUDIENCE);
+
+        ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+        verify(memberRepository).save(memberCaptor.capture());
+
+        Member savedMember = memberCaptor.getValue();
+        assertThat(savedMember.getName()).isEqualTo("seeatheater");
+        assertThat(savedMember.getUsername()).startsWith("seeatheater");
+        assertThat(savedMember.getPhone()).isNull();
+    }
+
+    @Test
+    void kakaoLoginRejectsUserInfoWithoutEmail() throws Exception {
+        KakaoTokenResponse kakaoToken = kakaoToken();
+        KakaoUserInfo userInfo = kakaoUserInfo("""
+                {
+                  "id": 12345,
+                  "kakao_account": {},
+                  "properties": {
+                    "nickname": "SeeATheater"
+                  }
+                }
+                """);
+
+        when(kakaoClient.getAccessToken("code", REDIRECT_URI)).thenReturn(kakaoToken);
+        when(kakaoClient.getUserInfo("kakao-access-token")).thenReturn(userInfo);
+
+        assertThatThrownBy(() -> authService.kakaoLogin("code", REDIRECT_URI, Role.AUDIENCE))
+                .isInstanceOfSatisfying(GeneralException.class, e ->
+                        assertThat(e.getCode()).isEqualTo(ErrorStatus.INVALID_KAKAO_USER_INFO));
+    }
+
+    private KakaoTokenResponse kakaoToken() throws Exception {
+        return objectMapper.readValue("""
+                {
+                  "access_token": "kakao-access-token",
+                  "refresh_token": "kakao-refresh-token"
+                }
+                """, KakaoTokenResponse.class);
+    }
+
+    private KakaoUserInfo kakaoUserInfo(String json) throws Exception {
+        return objectMapper.readValue(json, KakaoUserInfo.class);
+    }
+}


### PR DESCRIPTION
#⃣ 연관된 이슈
Part of ✨ [EPIC] 백엔드 운영 안정화 및 정합성 점검 #162

## 📝 작업 내용
Kakao OAuth 신규 회원가입 시 선택 제공 정보가 누락되어도 회원 생성이 가능하도록 수정했습니다.
- `email`, `kakaoId`는 필수값으로 유지했습니다.
- `nickname`이 없으면 이메일 앞부분을 fallback 값으로 사용하도록 했습니다.
- `name`이 없으면 nickname fallback 값을 사용하도록 했습니다.
- `phone_number`가 없으면 `null`로 저장하고, 값이 있을 때만 AES 암호화를 수행하도록 했습니다.
- 비활성 회원 재활성화 흐름에도 동일한 fallback 처리를 적용했습니다.
- 선택 제공 정보 누락 케이스에 대한 테스트를 추가했습니다.

## 📸 스크린샷 (선택)
없음

## 💬 리뷰 요구사항 (선택)
- Kakao OAuth에서 `email`, `kakaoId`만 필수로 유지하고 `nickname`, `name`, `phone_number`를 선택값으로 허용한 방식이 적절한지 확인 부탁드립니다.
- `phone_number`가 없는 경우 `null`로 저장하고, 값이 있을 때만 AES 암호화하는 방식이 기존 회원 정보 정책과 맞는지 검토 부탁드립니다.

## 참고
실수로 닫힌 PR #172와 동일한 변경을 복구한 PR입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Kakao authentication validation for more robust user data verification.
  * Improved handling of missing optional profile information during authentication.
  * Strengthened error handling for invalid authentication requests.

* **Tests**
  * Added comprehensive test coverage for Kakao authentication flows and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->