### PR TITLE
[DOCS] 검증 및 모니터링 문서 추가

### DIFF
--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -1,0 +1,139 @@
+# Acceptance Test Plan
+
+This plan defines manual acceptance tests before dev/staging release. It focuses on user-visible flows: login, show browsing, reservation, KakaoPay, performer registration, admin approval, auth expiry, and basic cleanup.
+
+Do not record real passwords, tokens, Authorization headers, or payment secrets in QA notes.
+
+## Test Environment
+
+| Item | Value |
+| --- | --- |
+| Frontend | `https://seeatheater.store` |
+| Backend | `https://api.seeatheater.store` |
+| Backend profile | dev/staging uses `SPRING_PROFILES_ACTIVE=dev` |
+| DB | dev/staging RDS only |
+| Redis | Docker Compose `redis` container |
+| S3 | dev/staging bucket via presigned URLs |
+
+## Test Accounts And Data
+
+Use dedicated dev/staging test accounts only. If a password is needed, share it out-of-band and do not paste it into logs or tickets.
+
+| Account Type | Required State | Notes |
+| --- | --- | --- |
+| Audience | ACTIVE, role `AUDIENCE` | Used for login, reserve, KakaoPay ready, my page |
+| Performer | ACTIVE, role `PERFORMER` | Used for show registration and registered show detail |
+| Admin | ACTIVE, role `ADMIN` | Used for approval/rejection and admin-only API checks |
+| Public shows | APPROVED and visible | Shows should have future rounds and tickets |
+| Payment data | No stale pending test tickets | Clean failed QA attempts when they block retest |
+
+## Scenario A: General User Login And Reservation
+
+| Field | Detail |
+| --- | --- |
+| Purpose | Verify a user can log in, browse shows, create a reservation, and reach KakaoPay ready. |
+| Preconditions | Audience test account exists; at least one approved show has future rounds and tickets. |
+| Steps | 1. Open FE. 2. Log in as audience. 3. Open show list. 4. Open show detail. 5. Click reservation. 6. Select round, ticket, quantity. 7. Submit reserve. 8. Trigger KakaoPay ready. |
+| Expected Result | User reaches KakaoPay payment redirect URL or payment window. No duplicate ready call from repeated click. |
+| APIs/DB | `GET /amateurs/ranking`, `GET /amateurs/{id}`, `POST /tickets/{showId}/reserve`, `POST /kakaoPay/ready?tempTicketId=...`, `temp_ticket`, `amateur_rounds.total_ticket` |
+| Logs | `/kakaoPay/ready`, reservation service logs, DB constraint logs |
+| Cleanup | Expire/cancel test TempTickets if they block repeat testing. |
+
+## Scenario B: KakaoPay Return Flow
+
+| Field | Detail |
+| --- | --- |
+| Purpose | Verify approve/cancel/fail callbacks preserve reservation and stock consistency. |
+| Preconditions | KakaoPay ready succeeds and callback URLs point to backend domain. |
+| Steps | 1. From KakaoPay window, approve one payment. 2. Repeat with cancel. 3. Repeat with fail if available. 4. Refresh/revisit callback URL only if safe. |
+| Expected Result | Approve creates one RealTicket. Cancel/fail do not create RealTicket and restore/expire TempTicket according to current policy. Duplicate approve does not create duplicate RealTicket. |
+| APIs/DB | `GET /kakaoPay/approve`, `/cancel`, `/fail`, `temp_ticket.reservation_status`, `real_ticket.kakao_tid`, `amateur_rounds.total_ticket` |
+| Logs | KakaoPay request/response status, `Duplicate entry`, `DataIntegrityViolationException` |
+| Cleanup | Cancel test tickets where supported; otherwise mark test records for later cleanup. |
+
+## Scenario C: Performer Flow
+
+| Field | Detail |
+| --- | --- |
+| Purpose | Verify performer can register a show and view registered show details. |
+| Preconditions | Performer account exists and can access performer routes. S3 upload env is configured. |
+| Steps | 1. Log in as performer. 2. Open show registration. 3. Upload poster. 4. Fill show info, rounds, tickets. 5. Submit. 6. Open my registered performances. |
+| Expected Result | Show is created with correct address, poster, rounds, tickets, and approval status. Registered detail includes `roadAddress` and `detailAddress`. |
+| APIs/DB | Performer show APIs, presigned upload API, `amateur_show`, `amateur_rounds`, `amateur_ticket`, `image` |
+| Logs | S3, show registration, validation errors |
+| Cleanup | Delete or reject test show if it should not remain public. |
+
+## Scenario D: Admin Flow
+
+| Field | Detail |
+| --- | --- |
+| Purpose | Verify admin can approve/reject shows and non-admin users cannot access admin APIs. |
+| Preconditions | Admin account exists; at least one waiting show exists. |
+| Steps | 1. Log in as admin. 2. Open admin dashboard. 3. Check waiting show list. 4. Approve one show. 5. Verify public exposure. 6. Reject another show if available. 7. Try admin route as non-admin. |
+| Expected Result | Admin actions succeed; approved shows become public; non-admin access returns 401/403. |
+| APIs/DB | `/admin/**`, `amateur_show.approval_status`, public show APIs |
+| Logs | Admin controller logs, access denied logs |
+| Cleanup | Restore approval state if the show was only for test. |
+
+## Scenario E: Auth Expiry, Refresh, And Logout
+
+| Field | Detail |
+| --- | --- |
+| Purpose | Verify session lifecycle and client cleanup behavior. |
+| Preconditions | User can log in and browser devtools are available. |
+| Steps | 1. Log in. 2. Call private API. 3. Expire/replace access token in test environment. 4. Verify refresh behavior. 5. Remove refresh token and retry. 6. Logout. |
+| Expected Result | Valid refresh keeps user logged in; invalid refresh clears session; logout clears local auth state even if API fails. |
+| APIs/DB | `/auth/refresh`, `/auth/logout`, Redis refresh token, private APIs |
+| Logs | Auth logs, Redis errors, 401/403 responses |
+| Cleanup | Clear browser storage. |
+
+## Public/Private API Baseline
+
+Run before and after release:
+
+```bash
+./scripts/dev-smoke-test.sh https://api.seeatheater.store
+```
+
+Expected checks include:
+
+- `/actuator/health` is public and UP.
+- Swagger is reachable in dev/staging.
+- `/kakaoPay/ready` rejects anonymous users.
+- `/kakaoPay/approve`, `/cancel`, `/fail` are public callbacks and reach validation.
+- My page and admin endpoints reject anonymous users.
+
+## QA Result Template
+
+```md
+# Acceptance Test Result
+
+- Date/time:
+- Tester:
+- FE URL:
+- BE URL:
+- FE commit/deploy:
+- BE commit/image:
+- DB profile:
+- Test accounts used:
+
+## Passed
+- [ ] Login
+- [ ] Reservation
+- [ ] KakaoPay ready
+- [ ] KakaoPay approve/cancel/fail
+- [ ] Performer registration
+- [ ] Admin approval
+- [ ] Refresh/logout
+- [ ] Smoke test
+
+## Failed / Blockers
+| Scenario | Symptom | Logs/API | Owner | Next Action |
+| --- | --- | --- | --- | --- |
+
+## Cleanup
+- [ ] Test TempTickets reviewed
+- [ ] Test RealTickets reviewed
+- [ ] Test shows reviewed
+- [ ] Browser storage cleared
+```

--- a/docs/ACCEPTANCE_TEST_PLAN.md
+++ b/docs/ACCEPTANCE_TEST_PLAN.md
@@ -46,7 +46,7 @@ Use dedicated dev/staging test accounts only. If a password is needed, share it 
 | Purpose | Verify approve/cancel/fail callbacks preserve reservation and stock consistency. |
 | Preconditions | KakaoPay ready succeeds and callback URLs point to backend domain. |
 | Steps | 1. From KakaoPay window, approve one payment. 2. Repeat with cancel. 3. Repeat with fail if available. 4. Refresh/revisit callback URL only if safe. |
-| Expected Result | Approve creates one RealTicket. Cancel/fail do not create RealTicket and restore/expire TempTicket according to current policy. Duplicate approve does not create duplicate RealTicket. |
+| Expected Result | First approve creates one RealTicket. A duplicate approve must not create a second RealTicket; QA should accept either idempotent success or a controlled non-5xx/known error only if DB state remains consistent. Cancel/fail do not create RealTicket and restore/expire TempTicket according to current policy. |
 | APIs/DB | `GET /kakaoPay/approve`, `/cancel`, `/fail`, `temp_ticket.reservation_status`, `real_ticket.kakao_tid`, `amateur_rounds.total_ticket` |
 | Logs | KakaoPay request/response status, `Duplicate entry`, `DataIntegrityViolationException` |
 | Cleanup | Cancel test tickets where supported; otherwise mark test records for later cleanup. |

--- a/docs/OPERATIONS_MONITORING.md
+++ b/docs/OPERATIONS_MONITORING.md
@@ -18,6 +18,8 @@ Prometheus/Grafana are not currently required for this release. They are listed 
 | Logs | Docker json-file log rotation configured for app and Redis |
 | Smoke test | `scripts/dev-smoke-test.sh` |
 
+This is a dev/staging baseline. Public `/actuator/health` with `show-details: always` is useful while validating RDS and Redis connectivity, but it is too verbose for production-facing operation. Before production release, harden Actuator exposure by limiting health details, restricting endpoint access, or separating internal health checks from public liveness checks.
+
 ## Health Check Baseline
 
 | Check | Command/API | Healthy Criteria |
@@ -233,6 +235,7 @@ Current project state:
 - `/actuator/health` and `/actuator/info` are exposed.
 - Prometheus dependency is not present.
 - `/actuator/prometheus` is not exposed.
+- Public health details are a dev/staging convenience and should be hardened before production.
 
 Current minimum monitoring is therefore:
 

--- a/docs/OPERATIONS_MONITORING.md
+++ b/docs/OPERATIONS_MONITORING.md
@@ -1,0 +1,261 @@
+# Operations Monitoring
+
+This document defines the minimum monitoring and incident response baseline for dev/staging. It focuses on what is available today: Spring Boot Actuator health, Docker Compose, Nginx logs, application logs, RDS checks, Redis container checks, smoke tests, and manual DB SELECTs.
+
+Prometheus/Grafana are not currently required for this release. They are listed as follow-up improvements because the project has Actuator but no Prometheus dependency or exposed `/actuator/prometheus` endpoint today.
+
+## Current Observability Facts
+
+| Area | Current State |
+| --- | --- |
+| Actuator dependency | Present: `spring-boot-starter-actuator` |
+| Exposed Actuator endpoints | `health,info` |
+| Health details | `show-details: always` in current config |
+| Prometheus dependency | Not present |
+| Prometheus endpoint | Not exposed |
+| Deployment | Docker Compose blue/green behind Nginx |
+| Redis | Docker Compose `redis` container |
+| Logs | Docker json-file log rotation configured for app and Redis |
+| Smoke test | `scripts/dev-smoke-test.sh` |
+
+## Health Check Baseline
+
+| Check | Command/API | Healthy Criteria |
+| --- | --- | --- |
+| Backend health | `curl -i https://api.seeatheater.store/actuator/health` | HTTP 200 and status `UP` |
+| Container status | `docker compose ps` | Active app and Redis running/healthy |
+| Nginx config | `sudo nginx -t` | Syntax OK and test successful |
+| Nginx proxy | `curl -i https://api.seeatheater.store/actuator/health` | No 502/504 |
+| Redis | Actuator health or `docker logs redis` | Redis UP; no repeated connection errors |
+| RDS | Actuator health DB component | DB UP; no connection pool failures |
+
+## Core Flow Monitoring
+
+| Flow | Signals To Watch | Failure Symptoms |
+| --- | --- | --- |
+| Kakao OAuth login | `/auth/kakao/callback`, Kakao profile parsing | 400/500, missing user fields, signup failure |
+| Review/general login | `/auth/review/login` while temporary | 401/403/500, wrong role, missing DB password hash |
+| Token refresh | `/auth/refresh`, Redis | repeated 401, refresh loop, Redis errors |
+| Logout | `/auth/logout` | local session remains, Redis delete failure |
+| Reservation | `/tickets/{showId}/reserve` | 400 validation, stock shortage, TempTicket not created |
+| KakaoPay ready | `/kakaoPay/ready` | KakaoPay 400/401/500, no redirect URL |
+| KakaoPay approve | `/kakaoPay/approve` | RealTicket missing, duplicate key, DB failure |
+| KakaoPay cancel/fail | `/kakaoPay/cancel`, `/fail` | stock not restored, TempTicket state wrong |
+| Admin approval | `/admin/**` | admin 403, approval state not changed |
+| S3 image | presigned GET/PUT APIs and image loads | 403, missing key, broken poster |
+
+## Log Locations And Commands
+
+```bash
+# EC2 app directory
+cd /home/ubuntu/ccapp
+
+# Containers
+docker compose ps
+docker logs --tail=200 ccapp-blue
+docker logs --tail=200 ccapp-green
+docker logs --tail=200 redis
+
+# Follow active logs during QA
+docker logs -f --tail=100 ccapp-blue
+docker logs -f --tail=100 ccapp-green
+
+# Nginx
+sudo nginx -t
+sudo tail -n 100 /var/log/nginx/access.log
+sudo tail -n 100 /var/log/nginx/error.log
+
+# Smoke test from local machine
+./scripts/dev-smoke-test.sh https://api.seeatheater.store
+```
+
+Do not paste Authorization headers or token values into logs, issue comments, or documents.
+
+## Log Keywords
+
+Search recent app logs for these keywords when a flow fails:
+
+```bash
+docker logs --tail=1000 ccapp-blue 2>&1 | grep -Ei 'kakaoPay|approve|ready|auth/refresh|auth/kakao|PHONENUM_ENCRYPT_FAIL|DataIntegrityViolationException|Duplicate entry|Redis|S3|JWT|403|500'
+docker logs --tail=1000 ccapp-green 2>&1 | grep -Ei 'kakaoPay|approve|ready|auth/refresh|auth/kakao|PHONENUM_ENCRYPT_FAIL|DataIntegrityViolationException|Duplicate entry|Redis|S3|JWT|403|500'
+```
+
+## Incident Priority
+
+### P0
+
+Escalate immediately if any of these happen:
+
+- `/actuator/health` is DOWN.
+- Nginx returns repeated 502/504.
+- 5xx responses repeat in a short time window.
+- KakaoPay ready repeatedly fails.
+- KakaoPay approve fails after payment authorization.
+- DB connection errors appear.
+- Redis connection errors prevent refresh token flows.
+- Duplicate RealTicket or stock inconsistency is suspected.
+
+### P1
+
+Investigate same day:
+
+- Refresh failures increase.
+- 401/403 responses spike unexpectedly.
+- S3 image 403 increases.
+- Admin approval API fails.
+- Show detail API returns 500.
+- Smoke test fails but health remains UP.
+
+## Runbooks
+
+### KakaoPay Ready Failure
+
+| Field | Detail |
+| --- | --- |
+| Symptom | User clicks payment but no KakaoPay redirect URL is returned. |
+| User Impact | Reservation cannot proceed to payment. |
+| First Checks | `curl /actuator/health`, app logs for `/kakaoPay/ready`, browser network response. |
+| Log Keywords | `kakaoPay`, `ready`, `400`, `401`, `KAKAOPAY` |
+| DB Checks | Latest `temp_ticket`, round stock, `kakao_tid` presence. |
+| Possible Causes | Callback domain not registered, wrong KakaoPay secret, invalid TempTicket, duplicate ready, stock shortage. |
+| Temporary Action | Confirm callback env and Kakao console; retry with clean TempTicket. |
+| Follow-Up | Add external API error mapping and alert on ready failure rate. |
+
+### KakaoPay Approve Failure
+
+| Field | Detail |
+| --- | --- |
+| Symptom | User returns from KakaoPay but ticket is not created. |
+| User Impact | Paid user may not see ticket. |
+| First Checks | App logs for `/kakaoPay/approve`; check `temp_ticket` and `real_ticket`. |
+| Log Keywords | `approve`, `pg_token`, `Duplicate entry`, `DataIntegrityViolationException` |
+| DB Checks | `real_ticket.kakao_tid`, `temp_ticket.reservation_status`, round stock. |
+| Possible Causes | Duplicate callback, DB constraint failure, external approve API failure, missing TempTicket. |
+| Temporary Action | Preserve logs and DB state; do not manually issue ticket without confirming payment state. |
+| Follow-Up | Idempotent approve handling and compensation policy. |
+
+### Login Or Refresh Failure
+
+| Field | Detail |
+| --- | --- |
+| Symptom | User cannot log in or is repeatedly redirected to login. |
+| User Impact | Authenticated flows unavailable. |
+| First Checks | Browser devtools network, `/auth/refresh` response, Redis health. |
+| Log Keywords | `auth/refresh`, `JWT`, `Redis`, `401`, `403` |
+| DB Checks | Member role/status for test account. |
+| Possible Causes | Redis token missing, expired refresh, bad FE auth state, wrong role, OAuth profile parsing failure. |
+| Temporary Action | Clear browser storage and retry; verify Redis container. |
+| Follow-Up | Add auth regression tests and monitor refresh failure count. |
+
+### Admin Page 403
+
+| Field | Detail |
+| --- | --- |
+| Symptom | Admin cannot access admin dashboard or API. |
+| User Impact | Show approval is blocked. |
+| First Checks | Member role is `ADMIN`; token authority; admin API response. |
+| Log Keywords | `AccessDenied`, `AuthorizationDeniedException`, `403` |
+| DB Checks | `SELECT email, role, active_status FROM member WHERE email = ...;` |
+| Possible Causes | Wrong role, stale token, selected role mismatch in FE, endpoint authority mismatch. |
+| Temporary Action | Re-login after verifying DB role. |
+| Follow-Up | Admin security regression tests. |
+
+### S3 Image 403
+
+| Field | Detail |
+| --- | --- |
+| Symptom | Poster or album image does not load. |
+| User Impact | Show pages look broken. |
+| First Checks | Image URL type, keyName, presigned URL generation logs. |
+| Log Keywords | `S3`, `presigned`, `403`, `keyName` |
+| DB Checks | `image.file_path`, `image.content_id`, `image.key_name`, `amateur_show.poster_image_url`. |
+| Possible Causes | Missing S3 object, private bucket without presigned URL, blank keyName, expired URL. |
+| Temporary Action | Reopen page to regenerate URL; verify object exists. |
+| Follow-Up | Consistent presigned URL policy for list/detail endpoints. |
+
+### Show Detail 500
+
+| Field | Detail |
+| --- | --- |
+| Symptom | Show detail page fails. |
+| User Impact | Users cannot view or reserve a show. |
+| First Checks | API response, app logs, show row and child rows. |
+| Log Keywords | `amateurShow`, `NullPointerException`, `S3`, `500` |
+| DB Checks | `amateur_show`, `amateur_rounds`, `amateur_ticket`, `image`. |
+| Possible Causes | Missing required child data, null address/poster fields, presigned URL failure. |
+| Temporary Action | Hide broken show or fix dev/staging seed data. |
+| Follow-Up | Add DTO null-safety and detail API regression test. |
+
+### DB Constraint Violation
+
+| Field | Detail |
+| --- | --- |
+| Symptom | API returns 500 or fails on save. |
+| User Impact | Reservation/payment/show registration may fail. |
+| First Checks | App logs for `DataIntegrityViolationException` and `Duplicate entry`. |
+| Log Keywords | `DataIntegrityViolationException`, `Duplicate entry`, `constraint` |
+| DB Checks | Relevant unique indexes and duplicate rows. |
+| Possible Causes | Duplicate `kakao_tid`, duplicate email, FK violation, nullable mismatch. |
+| Temporary Action | Do not delete production-like data blindly; collect SQL evidence. |
+| Follow-Up | Migration baseline and consistent exception mapping. |
+
+### Redis Connection Failure
+
+| Field | Detail |
+| --- | --- |
+| Symptom | Refresh/logout or health Redis component fails. |
+| User Impact | Users may be logged out or unable to refresh. |
+| First Checks | `docker compose ps redis`, app health, Redis logs. |
+| Log Keywords | `Redis`, `connection`, `timeout` |
+| DB Checks | Not applicable. |
+| Possible Causes | Redis container down, network issue, wrong `REDIS_HOST`. |
+| Temporary Action | Restart Redis/app in dev/staging if safe. |
+| Follow-Up | Evaluate ElastiCache or stronger Redis persistence/alerts. |
+
+### Nginx 502/504
+
+| Field | Detail |
+| --- | --- |
+| Symptom | API domain returns bad gateway or timeout. |
+| User Impact | Entire backend unavailable through public URL. |
+| First Checks | `sudo nginx -t`, `docker compose ps`, active upstream port. |
+| Log Keywords | `upstream`, `connect() failed`, `timed out` |
+| DB Checks | Not first-line unless app is crashing on DB startup. |
+| Possible Causes | Active app container down, wrong upstream, app port changed, healthcheck failed. |
+| Temporary Action | Switch to healthy blue/green container or rollback. |
+| Follow-Up | Automate active upstream verification and alerting. |
+
+## Prometheus And Grafana Follow-Up
+
+Current project state:
+
+- Actuator exists.
+- `/actuator/health` and `/actuator/info` are exposed.
+- Prometheus dependency is not present.
+- `/actuator/prometheus` is not exposed.
+
+Current minimum monitoring is therefore:
+
+- Health endpoint polling.
+- Smoke test execution after deploy.
+- Docker/Nginx/app log checks.
+- RDS/Redis status checks through health and AWS console.
+- Manual SQL checks for payment consistency after QA.
+
+Prometheus/Grafana would help with:
+
+- HTTP request rate, latency, and 5xx trends.
+- JVM memory and GC behavior.
+- DB connection pool saturation.
+- Endpoint-level KakaoPay/auth failure rates.
+- Alert rules for P0/P1 conditions.
+
+It is not required in the immediate dev/staging release because the project does not currently expose Prometheus metrics and the first operational target is release confidence, not full observability. It should be a follow-up once release flows are stable.
+
+Future tasks:
+
+- Add Micrometer Prometheus registry dependency.
+- Expose `/actuator/prometheus` in the appropriate profile.
+- Configure Prometheus scrape target.
+- Build Grafana dashboards.
+- Add alert rules for health DOWN, 5xx rate, KakaoPay failures, refresh failures, DB pool pressure, and JVM memory.

--- a/docs/PAYMENT_AUTH_RISK_REGISTER.md
+++ b/docs/PAYMENT_AUTH_RISK_REGISTER.md
@@ -1,0 +1,94 @@
+# Payment And Auth Risk Register
+
+This register tracks payment and authentication risks that can affect release readiness. It reflects the current codebase and dev/staging deployment model. It does not introduce schema or code changes by itself.
+
+Priority:
+
+- P0: Can block login, payment, reservation, or corrupt data.
+- P1: Can break major user flows or operations.
+- P2: Should be improved but does not block dev/staging if monitored.
+
+## Summary
+
+Current payment defenses include service-level validation, duplicate KakaoPay ready prevention, RealTicket duplicate prevention, and a DB unique constraint on `real_ticket.kakao_tid`. Remaining high-risk areas are transaction boundaries around external KakaoPay calls, cancel/fail/scheduler race conditions, and operational visibility for repeated payment/auth failures.
+
+## Risk Register
+
+| Risk ID | Priority | Risk | Impact | Trigger | Current Defense | Verification | Success Criteria | Remaining Risk | Follow-Up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| PAY-001 | P0 | `/kakaoPay/ready` duplicate call | Duplicate stock decrease or confusing payment state | Double click, retry, browser repeat | Service blocks ready when TempTicket already has `kakaoTid`; FE click guard expected | Unit test and manual repeated ready request | Second ready does not decrease stock | Concurrent calls can still race without DB-level idempotency key | Add idempotency key/state transition lock |
+| PAY-002 | P0 | Duplicate RealTicket for same approval | Duplicate ticket issuance | approve callback retry or refresh | `existsByKakaoTid`; DB unique index `uk_real_ticket_kakao_tid` | Query duplicate `kakao_tid`; retry approve | Only one RealTicket exists | Unique violation handling may surface as 500 under race | Catch duplicate key and return idempotent success |
+| PAY-003 | P0 | Invalid quantity or stock shortage | Negative/zero reservation or oversell | Bad request, FE bug, concurrent users | DTO/service validation; stock decrease repository method | quantity 0/-1 tests; stock shortage test | Invalid request rejected; stock not changed | High concurrency still needs pessimistic/optimistic lock audit | Add transaction/concurrency tests |
+| PAY-004 | P0 | KakaoPay callback URL mismatch | KakaoPay ready 400; payment cannot start | Domain not registered or env mismatch | Env-driven callback URLs | Check Kakao console and app logs | ready returns redirect URL | Console drift can recur | Add release checklist owner/signoff |
+| PAY-005 | P0 | KakaoPay external API failure | User cannot pay or approval fails | KakaoPay 400/401/500 | Logs and exception handling | Trigger test ready/approve | Failure is visible and does not corrupt DB | Error response may not be user-friendly | Standardize external API error mapping |
+| PAY-006 | P0 | External approve succeeds but DB save fails | Paid user has no ticket | DB outage, constraint failure after external call | Partial duplicate defense only | Simulate DB failure in test env | Failure is detected and compensating action defined | No outbox/compensation state machine yet | Design payment state machine/outbox |
+| PAY-007 | P1 | Cancel/fail/scheduler stock restore race | Stock restored more than once | Callback and scheduler overlap | Current status checks | Manual SQL/status review | Stock restored once | stopPayment is not fully atomic | Atomic state update before restore |
+| PAY-008 | P1 | `cancelTicket` non-idempotent behavior | Repeated cancellation or inconsistent status | User retry, network retry | Service status checks | Repeat cancel on same RealTicket | Later retries are safe | External cancel/API sequencing remains risky | Add idempotent cancel contract |
+| AUTH-001 | P0 | Access token expiry not refreshed | Users suddenly logged out | Expired token, failed interceptor | FE refresh flow; BE refresh endpoint | Expire access token in QA | Valid refresh reissues token | Redis token missing or FE state drift | Add regression tests and monitor refresh failures |
+| AUTH-002 | P0 | Refresh token missing/expired in Redis | Users cannot continue session | Redis restart, token TTL, logout | Redis-backed refresh token lifecycle | Redis health and auth flow QA | Client clears session and returns to login | Redis container persistence and monitoring are minimal | Add Redis persistence/alerting plan |
+| AUTH-003 | P1 | Duplicate refresh requests | Race causing bad token state | Multiple parallel 401 responses | FE single-flight expected | Browser devtools network | One refresh request for concurrent 401s | Needs FE regression coverage | Add FE auth tests |
+| AUTH-004 | P1 | Logout API failure leaves client session | User appears logged in after logout | Network or server failure | FE should clear local session regardless | Manual logout with network failure | Local tokens removed | Server refresh token may remain | Make logout idempotent and monitor failures |
+| AUTH-005 | P1 | 401/403 confusion | FE shows wrong UX or hides auth issue | Anonymous vs unauthorized request | Security handlers return 401/403 | Smoke test private/admin endpoints | Anonymous private API 401/403; admin non-admin forbidden | Some controllers may throw raw exceptions | Standardize auth error contract |
+| AUTH-006 | P1 | Kakao OAuth optional profile fields missing | Signup/login fails despite Kakao auth | `name`, `nickname`, `phone_number` absent | Optional fallback PR/test coverage expected | Kakao login with minimal profile | Account created with required fields only | Kakao console consent mismatch can recur | Keep OAuth field audit in release checklist |
+| AUTH-007 | P1 | Dev/review auth endpoint exposed longer than intended | Temporary bypass remains after review | PR not reverted | Whitelist and DB password verification | SecurityConfig audit | Only intended accounts work | Public endpoint still exists in prod-like env | Track revert issue and deadline |
+| S3-001 | P1 | S3 image 403 or presigned URL failure | Posters/images broken | Missing object, private bucket, bad key | Presigned GET fallback in detail flow | Open show detail images | Images load or fallback shown | List endpoints may still return raw URLs | Add list endpoint presigned strategy |
+| OPS-001 | P1 | Health is UP but business flow broken | Release appears healthy while payment/login fail | Health only checks infrastructure | Smoke test and acceptance tests | Run smoke + manual QA | Critical flows pass | No synthetic business monitoring yet | Add scheduled smoke job |
+
+## Payment State Checks
+
+Use SELECT-only checks before and after payment QA:
+
+```sql
+SELECT id, reservation_status, kakao_tid, quantity, amateur_round_id, amateur_ticket_id, member_id, created_at, updated_at
+FROM temp_ticket
+ORDER BY id DESC
+LIMIT 20;
+
+SELECT id, reservation_status, kakao_tid, quantity, amateur_rounds_id, member_id, reserve_date_time
+FROM real_ticket
+ORDER BY id DESC
+LIMIT 20;
+
+SELECT kakao_tid, COUNT(*) AS cnt
+FROM real_ticket
+WHERE kakao_tid IS NOT NULL
+GROUP BY kakao_tid
+HAVING COUNT(*) > 1;
+
+SELECT id, amateur_show_id, round_number, performance_date_time, total_ticket
+FROM amateur_rounds
+WHERE performance_date_time >= NOW()
+ORDER BY performance_date_time;
+```
+
+## Auth Contract Checks
+
+| Case | Expected BE Response | Expected FE Behavior |
+| --- | --- | --- |
+| Anonymous private API | 401 or 403 based on current security handler | Redirect/login prompt; no infinite retry |
+| Non-admin admin API | 403 | Show access denied or redirect safely |
+| Expired access + valid refresh | Refresh returns new access token | Retry original request once |
+| Expired/missing refresh | Refresh fails | Clear local auth state and go to login |
+| Logout success or failure | API may succeed/fail | Client clears local auth state either way |
+
+## Current Defense Layers
+
+| Layer | Current Defense | Gap |
+| --- | --- | --- |
+| FE | Button duplicate guard expected for payment; refresh single-flight expected | Needs regression testing after FE changes |
+| Controller/DTO | Ticket/payment validation baseline | Other domains still need validation expansion |
+| Service | ready duplicate check, quantity checks, member ownership checks | Stop/cancel transaction boundary remains risky |
+| DB | `real_ticket.kakao_tid` unique index | No full payment state machine or idempotency table |
+| Ops | Smoke test, health check, Docker/Nginx logs | No automated scheduled synthetic monitor |
+
+## P0 Release Gate
+
+Do not release if any of these are unverified:
+
+- KakaoPay ready succeeds for an authenticated user.
+- Duplicate ready call does not double-decrease stock.
+- Approve creates at most one RealTicket.
+- Anonymous `/kakaoPay/ready` is blocked.
+- KakaoPay callbacks remain public.
+- Login/refresh/logout works without infinite retry.
+- Redis and DB are both UP in health.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,114 @@
+# Release Checklist
+
+This checklist is the go/no-go gate for dev/staging release of the See A Theater backend. It reflects the current deployment model: Docker Hub -> EC2 -> Docker Compose blue/green -> Nginx -> Spring Boot dev profile with RDS, Redis container, S3, Kakao OAuth, and KakaoPay.
+
+Do not paste secrets, tokens, passwords, or Authorization headers into this document or release notes.
+
+## Release Inputs
+
+| Item | Expected Value | How To Check | Success Criteria | If It Fails |
+| --- | --- | --- | --- | --- |
+| Backend API URL | `https://api.seeatheater.store` | Browser or `curl -i https://api.seeatheater.store/actuator/health` | HTTPS responds and health is `UP` | Check DNS, Nginx, active app container, Security Group 80/443 |
+| Frontend URL | `https://seeatheater.store` | Browser open | App loads without asset, CORS, or routing failure | Check FE deployment and browser console |
+| FE API base URL | Backend API domain | Browser devtools Network tab | API calls go to `https://api.seeatheater.store` | Check `VITE_APP_API_URL` and redeploy FE |
+| Backend profile | `SPRING_PROFILES_ACTIVE=dev` for dev/staging | EC2 `.env` and container env | App uses `DEV_DB_URL` | Check `/home/ubuntu/ccapp/.env` and recreate app container |
+| Docker image | Expected Docker Hub image/tag | GitHub Actions logs and EC2 `docker images` | Active container uses intended image | Check GitHub variables/secrets and Docker Hub push |
+
+## Go/No-Go Checklist
+
+| Check Item | How To Check | Success Criteria | Failure Location |
+| --- | --- | --- | --- |
+| Health endpoint | `curl -i https://api.seeatheater.store/actuator/health` | HTTP 200 and health status `UP` | App logs, DB, Redis, Docker healthcheck |
+| Docker containers | `docker compose ps` on EC2 | Active app container and `redis` are `running` or `healthy` | `docker logs <container>` |
+| Nginx reverse proxy | `curl -i https://api.seeatheater.store/actuator/health` and `sudo nginx -t` | No 502/504, Nginx config valid | `/var/log/nginx/error.log`, upstream port |
+| Blue/green active target | Inspect Nginx upstream and app ports | Nginx points to one healthy app container | `switch-blue-green.sh`, `rollback.sh`, Nginx config |
+| Public/private smoke test | `./scripts/dev-smoke-test.sh https://api.seeatheater.store` | All checks pass | `docs/PUBLIC_ENDPOINT_BASELINE.md`, SecurityConfig, app logs |
+| FE API target | Browser devtools Network | FE calls API domain, not localhost or stale IP | FE env and Vercel/deploy config |
+| CORS | Browser request from FE origin | No browser CORS failure | `CORS_ALLOWED_ORIGINS`, SecurityConfig, Nginx |
+| Kakao Developers domains | Kakao Developers console | `https://seeatheater.store` and `https://api.seeatheater.store` are registered as needed | Kakao console platform/domain settings |
+| KakaoPay callback URLs | KakaoPay env and app logs | approve/cancel/fail point to backend API domain | `KAKAOPAY_APPROVE_URL`, `KAKAOPAY_CANCEL_URL`, `KAKAOPAY_FAIL_URL` |
+| KakaoPay ready | Authenticated user clicks payment | Response returns payment redirect URL | KakaoPay logs, callback domain, request payload |
+| KakaoPay approve/cancel/fail | Return from KakaoPay flow | Callback reaches backend and redirects/returns expected state | App logs for `/kakaoPay/approve`, `/cancel`, `/fail` |
+| General user login | FE login flow | Access token issued and protected pages load | Auth logs, browser storage, Redis refresh token |
+| Reservation flow | Login -> show detail -> ticket select -> reserve | TempTicket is created and ready can be called | `temp_ticket`, stock in `amateur_rounds` |
+| My page ticket view | After reservation/payment | Ticket state appears correctly | MyTicket API logs, `real_ticket` |
+| Performer show registration | Performer account creates show | Show is created in waiting/expected status | Performer API logs, S3 upload, `amateur_show` |
+| Admin approval | Admin approves/rejects waiting show | Approved show appears publicly; rejected show stays hidden | Admin API logs, `amateur_show.approval_status` |
+| Access token refresh | Expired access token with valid refresh | Refresh succeeds and user stays logged in | `/auth/refresh`, Redis, FE interceptor |
+| Refresh failure | Invalid/missing refresh token | Client clears session and returns to login | Browser storage, auth logs |
+| Logout | User clicks logout | Client session is cleared even if API fails | FE auth state, `/auth/logout`, Redis |
+| QA/demo data cleanup | Check known prefixes | No stale broken QA data is public | SELECT-only checks, cleanup SQL reviewed before execution |
+| Rollback readiness | Review scripts and active container | `rollback.sh` and previous container/image are available | `/tmp/rollback.log`, Docker image list |
+
+## Required Commands
+
+```bash
+# Public smoke baseline
+./scripts/dev-smoke-test.sh https://api.seeatheater.store
+
+# EC2 container status
+cd /home/ubuntu/ccapp
+docker compose ps
+
+docker logs --tail=200 ccapp-blue
+docker logs --tail=200 ccapp-green
+docker logs --tail=200 redis
+
+# Nginx
+sudo nginx -t
+sudo tail -n 100 /var/log/nginx/error.log
+sudo tail -n 100 /var/log/nginx/access.log
+
+# Health
+curl -i https://api.seeatheater.store/actuator/health
+```
+
+## SELECT-Only DB Checks
+
+Use the dev/staging database only. Do not run against production.
+
+```sql
+SELECT id, name, approval_status, status, `start`, `end`
+FROM amateur_show
+WHERE approval_status = 'APPROVED'
+ORDER BY id DESC;
+
+SELECT amateur_show_id, round_number, performance_date_time, total_ticket
+FROM amateur_rounds
+WHERE performance_date_time >= NOW()
+ORDER BY amateur_show_id, performance_date_time;
+
+SELECT reservation_status, COUNT(*)
+FROM temp_ticket
+GROUP BY reservation_status;
+
+SELECT reservation_status, COUNT(*)
+FROM real_ticket
+GROUP BY reservation_status;
+
+SELECT kakao_tid, COUNT(*) AS cnt
+FROM real_ticket
+WHERE kakao_tid IS NOT NULL
+GROUP BY kakao_tid
+HAVING COUNT(*) > 1;
+```
+
+## Go/No-Go Decision
+
+Release can proceed only if:
+
+- `/actuator/health` is `UP`.
+- Smoke test passes.
+- Active app container is healthy behind Nginx.
+- FE calls the correct API URL.
+- Login, reserve, KakaoPay ready, and admin approval are manually verified at least once.
+- Kakao Developers and KakaoPay callback domains match the deployed URLs.
+- No known P0 risk in `docs/PAYMENT_AUTH_RISK_REGISTER.md` remains unverified.
+
+Release should stop if:
+
+- Health is DOWN or Nginx returns 502/504.
+- KakaoPay ready fails repeatedly.
+- Login/refresh fails for normal users.
+- Reservation creates inconsistent TempTicket/stock state.
+- Admin cannot approve shows or non-admin can access admin APIs.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -102,6 +102,8 @@ Release can proceed only if:
 - Active app container is healthy behind Nginx.
 - FE calls the correct API URL.
 - Login, reserve, KakaoPay ready, and admin approval are manually verified at least once.
+- Duplicate `/kakaoPay/ready` on the same TempTicket is verified not to double-decrease stock.
+- Duplicate KakaoPay approve is verified not to create more than one RealTicket for the same `kakao_tid`.
 - Kakao Developers and KakaoPay callback domains match the deployed URLs.
 - No known P0 risk in `docs/PAYMENT_AUTH_RISK_REGISTER.md` remains unverified.
 


### PR DESCRIPTION
#⃣ 연관된 이슈
- Part of ✨ [EPIC] 백엔드 운영 안정화 및 정합성 점검 #162

## 📝 작업 내용
dev/staging 운영 전 배포 가능 여부를 판단할 수 있도록 운영 전 검증 및 모니터링 기준 문서를 추가했습니다.
- `docs/RELEASE_CHECKLIST.md`
  - dev/staging release go/no-go 체크리스트 작성
- `docs/ACCEPTANCE_TEST_PLAN.md`
  - 로그인, 예매, KakaoPay, 공연진 등록, 관리자 승인, refresh/logout 인수 테스트 계획 작성
- `docs/PAYMENT_AUTH_RISK_REGISTER.md`
  - 결제/인증 중심 운영 리스크와 검증 기준 정리
- `docs/OPERATIONS_MONITORING.md`
  - Actuator, Docker, Nginx, RDS, Redis, KakaoPay/Auth 로그 기반 최소 모니터링 기준 및 장애 대응 runbook 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added acceptance testing plan documenting manual testing coverage for key user flows (login, reservations, payments, admin functions).
  * Added operations monitoring baseline with health checks, log monitoring, and incident response procedures.
  * Added payment and authentication risk register identifying potential issues and defense layers.
  * Added release checklist defining verification steps and release gate criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->