### PR TITLE
[REFACTOR] 인프로세스 승인 알림 처리 안정화

### DIFF
--- a/src/main/java/cc/backend/admin/amateurShow/service/AdminApprovalService.java
+++ b/src/main/java/cc/backend/admin/amateurShow/service/AdminApprovalService.java
@@ -4,6 +4,7 @@ import cc.backend.admin.amateurShow.dto.AdminAmateurShowRejectRequestDTO;
 import cc.backend.admin.amateurShow.dto.AdminAmateurShowSummaryResponseDTO;
 import cc.backend.admin.amateurShow.dto.AdminApprovalListResponseDTO;
 import cc.backend.amateurShow.entity.AmateurShow;
+import cc.backend.amateurShow.entity.enums.ApprovalStatus;
 import cc.backend.amateurShow.repository.AmateurShowRepository;
 import cc.backend.apiPayLoad.PageResponse;
 import cc.backend.apiPayLoad.code.status.ErrorStatus;
@@ -32,10 +33,21 @@ public class AdminApprovalService {
         AmateurShow show = amateurShowRepository.findById(showId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
+        if (show.getApprovalStatus() == ApprovalStatus.APPROVED) {
+            throw new GeneralException(ErrorStatus.AMATEURSHOW_ALREADY_APPROVED);
+        }
+
         show.approve();
 
         Member member  = show.getMember();
-        eventPublisher.publishEvent(new ApproveShowEvent(show, member));   //공연등록 승인 이벤트 생성
+        eventPublisher.publishEvent(
+                new ApproveShowEvent(
+                        show.getId(),
+                        member.getId(),
+                        show.getName(),
+                        show.getHashtag()
+                )
+        );   //공연등록 승인 이벤트 생성
 
         return AdminAmateurShowSummaryResponseDTO.from(show);
     }

--- a/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -81,6 +81,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AMATEURSHOW_NOT_FOUND(HttpStatus.NOT_FOUND, "AMATEURSHOW4000", "존재하지 않는 소극장 공연입니다."),
     INVALID_DATE_RANGE(HttpStatus.NOT_ACCEPTABLE, "AMATEURSHOW4001", "공연 시작 날짜는 종료 날짜 이전이어햐 합니다."),
     NOT_APPROVED_SHOW(HttpStatus.FORBIDDEN, "AMATEURSHOW4002", "승인되지 않은 소극장 공연입니다."),
+    AMATEURSHOW_ALREADY_APPROVED(HttpStatus.CONFLICT, "AMATEURSHOW4003", "이미 승인된 소극장 공연입니다."),
 
 
     // AMATEUR TICKET ERROR

--- a/src/main/java/cc/backend/event/entity/ApproveShowEvent.java
+++ b/src/main/java/cc/backend/event/entity/ApproveShowEvent.java
@@ -1,16 +1,18 @@
 package cc.backend.event.entity;
 
-import cc.backend.amateurShow.entity.AmateurShow;
-import cc.backend.member.entity.Member;
 import lombok.Getter;
 
 @Getter
 public class ApproveShowEvent {
-    private final AmateurShow amateurShow;
-    private final Member member;   //공연 등록자
+    private final Long amateurShowId;
+    private final Long memberId;   //공연 등록자
+    private final String showName;
+    private final String hashtag;
 
-    public ApproveShowEvent(AmateurShow amateurShow, Member member) {
-        this.amateurShow = amateurShow;
-        this.member = member;
+    public ApproveShowEvent(Long amateurShowId, Long memberId, String showName, String hashtag) {
+        this.amateurShowId = amateurShowId;
+        this.memberId = memberId;
+        this.showName = showName;
+        this.hashtag = hashtag;
     }
 }

--- a/src/main/java/cc/backend/event/service/ApproveShowEventListener.java
+++ b/src/main/java/cc/backend/event/service/ApproveShowEventListener.java
@@ -1,23 +1,37 @@
 package cc.backend.event.service;
 
 import cc.backend.event.entity.ApproveShowEvent;
-import cc.backend.notice.dto.NoticeResponseDTO;
 import cc.backend.notice.service.NoticeService;
+import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ApproveShowEventListener {
     private final NoticeService noticeService;
 
-    @EventListener
-    public NoticeResponseDTO.NoticeDTO handleApproveShowEvent(ApproveShowEvent event) {
-        NoticeResponseDTO.NoticeDTO approvalNotice = noticeService.notifyApproval(event);
-        noticeService.notifyLikers(event);
-        noticeService.notifyRecommendation(event);
-        return approvalNotice;
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleApproveShowEvent(ApproveShowEvent event) {
+        executeSafely("approval", event, () -> noticeService.notifyApproval(event));
+        executeSafely("likers", event, () -> noticeService.notifyLikers(event));
+        executeSafely("recommendation", event, () -> noticeService.notifyRecommendation(event));
     }
 
+    private void executeSafely(String notificationType, ApproveShowEvent event, Runnable task) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            log.error(
+                    "공연 승인 알림 처리 실패: type={}, showId={}, memberId={}",
+                    notificationType,
+                    event.getAmateurShowId(),
+                    event.getMemberId(),
+                    e
+            );
+        }
+    }
 }

--- a/src/main/java/cc/backend/memberLike/repository/MemberLikeRepository.java
+++ b/src/main/java/cc/backend/memberLike/repository/MemberLikeRepository.java
@@ -40,6 +40,13 @@ public interface MemberLikeRepository extends JpaRepository<MemberLike, Long> {
     );
 
     @Query("""
+        SELECT ml.liker
+        FROM MemberLike ml
+        WHERE ml.performer.id = :performerId
+    """)
+    List<Member> findLikersByPerformerId(@Param("performerId") Long performerId);
+
+    @Query("""
         SELECT DISTINCT ml.liker
         FROM MemberLike ml
         WHERE ml.performer.id IN :performerIds

--- a/src/main/java/cc/backend/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/cc/backend/notice/service/NoticeServiceImpl.java
@@ -1,7 +1,6 @@
 package cc.backend.notice.service;
 
 import cc.backend.amateurShow.entity.AmateurShow;
-import cc.backend.amateurShow.entity.AmateurTicket;
 import cc.backend.amateurShow.repository.AmateurShowRepository;
 import cc.backend.amateurShow.repository.AmateurTicketRepository;
 import cc.backend.amateurShow.entity.enums.ApprovalStatus;
@@ -15,19 +14,16 @@ import cc.backend.board.repository.CommentRepository;
 import cc.backend.event.entity.*;
 import cc.backend.member.entity.Member;
 import cc.backend.member.repository.MemberRepository;
-import cc.backend.memberLike.entity.MemberLike;
 import cc.backend.memberLike.repository.MemberLikeRepository;
-import cc.backend.notice.dto.MemberNoticeResponseDTO;
 import cc.backend.notice.dto.NoticeResponseDTO;
 import cc.backend.notice.entity.MemberNotice;
 import cc.backend.notice.entity.Notice;
 import cc.backend.notice.entity.enums.NoticeType;
 import cc.backend.notice.repository.MemberNoticeRepository;
 import cc.backend.notice.repository.NoticeRepository;
-import cc.backend.photoAlbum.dto.PhotoAlbumResponseDTO;
-import cc.backend.photoAlbum.entity.PhotoAlbum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
@@ -224,18 +220,21 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public NoticeResponseDTO.NoticeDTO notifyApproval(ApproveShowEvent event) {
+        Member receiver = memberRepository.findById(event.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
         Notice notice = noticeRepository.save(Notice.builder()
                 .type(NoticeType.AMATEURSHOW)
-                .message("요청하신 " + "'" + event.getAmateurShow().getName() + "'"+ " 공연 등록이 승인되었습니다.")
-                .contentId(event.getAmateurShow().getId())
+                .message("요청하신 " + "'" + event.getShowName() + "'"+ " 공연 등록이 승인되었습니다.")
+                .contentId(event.getAmateurShowId())
                 .build()
         );
 
         memberNoticeRepository.save(MemberNotice.builder()
                 .notice(notice)
-                .member(event.getMember())
+                .member(receiver)
                 .build()
         );
 
@@ -249,28 +248,25 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public NoticeResponseDTO.NoticeDTO notifyLikers(ApproveShowEvent event) {
-        AmateurShow show = event.getAmateurShow();
-        List<MemberLike> likers = memberLikeRepository.findByPerformerId(
-                event.getMember().getId()
-        );
+        List<Member> likers = memberLikeRepository.findLikersByPerformerId(event.getMemberId());
         if (likers.isEmpty()) return null;
 
         Notice notice = noticeRepository.save(
                 Notice.builder()
                         .type(NoticeType.AMATEURSHOW)
-                        .message("소극장 공연 '" + show.getName()
+                        .message("소극장 공연 '" + event.getShowName()
                                 + "' 등록 완료! 소극장 공연 페이지에서 확인해보세요!")
-                        .contentId(show.getId())
+                        .contentId(event.getAmateurShowId())
                         .build()
         );
 
         memberNoticeRepository.saveAll(
                 likers.stream()
-                        .map(like -> MemberNotice.builder()
+                        .map(liker -> MemberNotice.builder()
                                 .notice(notice)
-                                .member(like.getLiker())
+                                .member(liker)
                                 .build())
                         .toList()
         );
@@ -285,24 +281,23 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public NoticeResponseDTO.NoticeDTO notifyRecommendation(ApproveShowEvent event) {
-        AmateurShow show = event.getAmateurShow();
-        if (noticeRepository.existsByContentIdAndType(show.getId(), NoticeType.RECOMMEND)) {
+        if (noticeRepository.existsByContentIdAndType(event.getAmateurShowId(), NoticeType.RECOMMEND)) {
             return null;
         }
 
-        Set<String> newTags = parseHashtags(show.getHashtag());
+        Set<String> newTags = parseHashtags(event.getHashtag());
         if (newTags.isEmpty()) return null;
 
-        List<Member> targets = findRecommendationTargets(show, newTags);
+        List<Member> targets = findRecommendationTargets(event.getAmateurShowId(), newTags);
         if (targets.isEmpty()) return null;
 
         Notice notice = noticeRepository.save(
                 Notice.builder()
                         .type(NoticeType.RECOMMEND)
-                        .message("새로운 공연 '" + show.getName() + "' 어떠세요?")
-                        .contentId(show.getId())
+                        .message("새로운 공연 '" + event.getShowName() + "' 어떠세요?")
+                        .contentId(event.getAmateurShowId())
                         .build()
         );
 
@@ -311,7 +306,7 @@ public class NoticeServiceImpl implements NoticeService {
                         .map(member -> MemberNotice.builder()
                                 .member(member)
                                 .notice(notice)
-                                .personalMsg(createPersonalMessage(show, member))
+                                .personalMsg(createPersonalMessage(event.getShowName(), event.getHashtag(), member))
                                 .isRead(false)
                                 .build())
                         .toList()
@@ -333,11 +328,11 @@ public class NoticeServiceImpl implements NoticeService {
                 .collect(Collectors.toSet());
     }
 
-    private List<Member> findRecommendationTargets(AmateurShow newShow, Set<String> newTags) {
+    private List<Member> findRecommendationTargets(Long newShowId, Set<String> newTags) {
         Set<Long> matchedPerformerIds = amateurShowRepository
                 .findApprovedHistoricalPerformerHashtags(
                         ApprovalStatus.APPROVED,
-                        newShow.getId()
+                        newShowId
                 )
                 .stream()
                 .filter(row -> !Collections.disjoint(
@@ -354,9 +349,9 @@ public class NoticeServiceImpl implements NoticeService {
         );
     }
 
-    private String createPersonalMessage(AmateurShow show, Member member) {
-        return "새로운 공연 '" + show.getName() + "' 어떠세요? "
-                + show.getHashtag() + " "
+    private String createPersonalMessage(String showName, String hashtag, Member member) {
+        return "새로운 공연 '" + showName + "' 어떠세요? "
+                + Optional.ofNullable(hashtag).orElse("") + " "
                 + member.getName() + "님 취향에 딱!";
     }
 


### PR DESCRIPTION
  단일 인프로세스 Spring Event 기반 알림 구조에서 공연 승인 알림 처리의 안정성과 성능을 개선했습니다.

  승인 트랜잭션과 알림 저장 로직의 결합을 줄이고, 알림 3종이 서로 독립적으로 처리되도록 변경했습니다. 또한 승인 이벤트가 JPA 엔티티를 직접 들고 다니지 않도록 스냅샷 기반 이벤트
  로 변경하고, 좋아요 알림 대상 조회 비용을 줄였습니다.

  ## 주요 변경사항

  ### 1. 승인 알림을 커밋 이후 처리

  기존 `@EventListener` 기반 승인 알림 처리는 `AdminApprovalService.approveShow()` 트랜잭션 안에서 실행되었습니다.

  ```text
  공연 승인
  → 승인 상태 변경
  → ApplicationEventPublisher.publishEvent()
  → @EventListener
  → 알림 저장
  → 승인 트랜잭션 커밋
```

  이 경우 알림 저장 중 예외가 발생하면 공연 승인 자체가 롤백될 수 있습니다.

  이를 방지하기 위해 승인 알림 리스너를 다음 방식으로 변경했습니다.

  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

  변경 후 흐름:

  공연 승인
  → 승인 상태 변경
  → 승인 트랜잭션 커밋
  → AFTER_COMMIT 이벤트 리스너 실행
  → 알림 저장

  ### 2. 승인 알림 3종 실패 격리

  승인 이벤트 발생 시 처리되는 알림은 다음 3종입니다.

  1. 공연 등록자 승인 알림
  2. 공연자를 좋아요한 사용자 대상 알림
  3. 추천 알림

  기존에는 중간 알림 처리에서 예외가 발생하면 이후 알림 처리가 중단될 수 있었습니다.

  현재는 각 알림을 독립적으로 실행하고, 개별 실패는 로깅 후 다음 알림 처리를 계속하도록 변경했습니다.

  notifyApproval 실패
  → 로그 기록
  → notifyLikers 계속 실행
  → notifyRecommendation 계속 실행

  ### 3. 알림 저장 트랜잭션 분리

  승인 알림 3종을 각각 별도 트랜잭션으로 저장하도록 변경했습니다.

  @Transactional(propagation = Propagation.REQUIRES_NEW)

  적용 대상:

  notifyApproval()
  notifyLikers()
  notifyRecommendation()

  이를 통해 특정 알림 저장 실패가 다른 알림 저장 결과까지 롤백시키지 않도록 했습니다.

  ### 4. 승인 이벤트를 엔티티 참조에서 스냅샷 기반으로 변경

  기존 승인 이벤트는 JPA 엔티티를 직접 들고 있었습니다.

  new ApproveShowEvent(show, member)

  변경 후에는 알림 처리에 필요한 최소 값만 이벤트에 담습니다.

  new ApproveShowEvent(
      show.getId(),
      member.getId(),
      show.getName(),
      show.getHashtag()
  )

  이를 통해 커밋 이후 이벤트 처리 시 영속성 컨텍스트 경계나 Lazy Loading 의존성을 줄였습니다.

  ### 5. 이미 승인된 공연 재승인 차단

  이미 승인된 공연에 대해 승인 API가 다시 호출될 경우 중복 알림이 생성될 수 있어, 재승인을 명시적으로 차단했습니다.

  추가한 에러 상태:

  AMATEURSHOW_ALREADY_APPROVED(
      HttpStatus.CONFLICT,
      "AMATEURSHOW4003",
      "이미 승인된 소극장 공연입니다."
  )

  ### 6. 좋아요 알림 대상 조회 최적화

  기존에는 공연자를 좋아요한 사용자 조회 시 MemberLike 엔티티 전체를 조회한 뒤 liker를 꺼냈습니다.

  List<MemberLike> likers = memberLikeRepository.findByPerformerId(performerId);

  변경 후에는 실제 필요한 Member만 직접 조회합니다.

  @Query("""
      SELECT ml.liker
      FROM MemberLike ml
      WHERE ml.performer.id = :performerId
  """)
  List<Member> findLikersByPerformerId(@Param("performerId") Long performerId);

  불필요한 엔티티 로딩을 줄여 fan-out 알림 대상 조회 비용을 낮췄습니다.

  ## 변경된 주요 파일

  src/main/java/cc/backend/admin/amateurShow/service/AdminApprovalService.java
  src/main/java/cc/backend/apiPayLoad/code/status/ErrorStatus.java
  src/main/java/cc/backend/event/entity/ApproveShowEvent.java
  src/main/java/cc/backend/event/service/ApproveShowEventListener.java
  src/main/java/cc/backend/memberLike/repository/MemberLikeRepository.java
  src/main/java/cc/backend/notice/service/NoticeServiceImpl.java


  ## 참고

  이 PR은 Kafka/Outbox 구조를 도입하지 않고, 단일 인프로세스 Spring Event 기반 알림 구조를 유지한 상태에서 개선한 작업입니다.

  따라서 커밋 이후 애플리케이션이 종료되는 경우 알림 이벤트가 유실될 수 있는 한계는 여전히 존재합니다. 이 문제는 별도 Outbox 기반 구조에서 해결할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented already-approved amateur shows from being approved again, with a clear conflict message.
  * Improved approval notifications so failures in one notification do not block others.
  * Ensured notifications are sent only after approval changes are successfully committed.

* **Improvements**
  * Enhanced approval notifications for show hosts, likers, and recommendations.
  * Improved personalized messaging, including safer handling of missing hashtags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->